### PR TITLE
Add helix sequence tests

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,0 +1,19 @@
+name: Python Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: pip install pytest
+      - name: Run tests
+        run: pytest -q

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+.pytest_cache/

--- a/tests/test_collaboration.py
+++ b/tests/test_collaboration.py
@@ -1,0 +1,63 @@
+import pathlib
+import types
+import pytest
+
+MODULE_PATH = pathlib.Path(__file__).resolve().parents[1] / "collaboration"
+
+
+def load_module(path: pathlib.Path):
+    """Load the 'collaboration' script as a module despite non-Python preamble."""
+    text = path.read_text()
+    lines = text.splitlines()
+    # Find the first line that looks like Python code
+    start = 0
+    for i, line in enumerate(lines):
+        if line.startswith("import") or line.startswith("from") or line.startswith("class"):
+            start = i
+            break
+    code = "\n".join(lines[start:])
+    module = types.ModuleType("collaboration")
+    exec(code, module.__dict__)
+    return module
+
+
+collaboration = load_module(MODULE_PATH)
+QuantumCollaborationInterface = collaboration.QuantumCollaborationInterface
+
+
+@pytest.fixture
+def qci():
+    return QuantumCollaborationInterface()
+
+
+def test_sequence_too_short(qci):
+    result = qci._validate_helix_sequence("ATCG")
+    assert result["valid"] is False
+    assert result["reason"] == "Sequence too short"
+    assert result["score"] == 0.2
+
+
+def test_valid_sequence_no_quantum(qci):
+    sequence = "ATCG01+-ATCG01+-"  # 8 valid complementary pairs
+    result = qci._validate_helix_sequence(sequence)
+    assert result["valid"] is True
+    assert result["pair_validity"] == 1.0
+    assert result["quantum_pattern_present"] is False
+    assert result["score"] == 0.7
+
+
+def test_valid_sequence_with_quantum(qci):
+    sequence = "ATCG01+-ATCG01+-Q"  # valid pairs plus quantum marker
+    result = qci._validate_helix_sequence(sequence)
+    assert result["valid"] is True
+    assert result["pair_validity"] == 1.0
+    assert result["quantum_pattern_present"] is True
+    assert result["score"] == 1.0
+
+
+def test_invalid_sequence_insufficient_pairs(qci):
+    sequence = "AACCGGTTAACCGGTTQ"  # No complementary pairs
+    result = qci._validate_helix_sequence(sequence)
+    assert result["valid"] is False
+    assert result["score"] == pytest.approx(0.3)
+    assert result["quantum_pattern_present"] is True


### PR DESCRIPTION
## Summary
- add pytest workflow
- add tests for QuantumCollaborationInterface._validate_helix_sequence
- add .gitignore for cache folders

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687ebfd093008333aedbe69543df64f6