### PR TITLE
Fix anchor script dependency issue

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+addopts = -q
+pythonpath = 
+    tas_pythonetics/src
+    truealpha_singularity/src

--- a/scripts/itl_anchor.py
+++ b/scripts/itl_anchor.py
@@ -1,0 +1,42 @@
+import hashlib
+import pathlib
+import json
+import datetime
+try:
+    import requests
+except ImportError:  # Fallback to urllib if requests isn't installed
+    requests = None
+    import urllib.request
+
+def sha_tree(root="tas_pythonetics"):
+    h = hashlib.sha256()
+    for p in sorted(pathlib.Path(root).rglob("*")):
+        if p.is_file():
+            h.update(p.read_bytes())
+    return h.hexdigest()
+
+payload = {
+    "hash": sha_tree(),
+    "author": "Russell Nordland",
+    "timestamp": datetime.datetime.utcnow().isoformat() + "Z",
+    "version": "0.1.0",
+}
+# Replace with real TAS_ITL_API endpoint/token
+def _post(url: str, data: dict):
+    try:
+        if requests:
+            requests.post(url, json=data)
+        else:
+            encoded = json.dumps(data).encode()
+            req = urllib.request.Request(
+                url,
+                data=encoded,
+                headers={"Content-Type": "application/json"},
+            )
+            with urllib.request.urlopen(req) as resp:
+                resp.read()
+    except Exception as e:  # Network errors should not crash the script
+        print(f"Failed to submit anchor: {e}")
+
+_post("https://tas.itl/anchor", payload)
+print("ITL anchor submitted:", payload["hash"])

--- a/tas_pythonetics/.gitignore
+++ b/tas_pythonetics/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+build/
+dist/
+*.egg-info/

--- a/tas_pythonetics/CHANGELOG.md
+++ b/tas_pythonetics/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Changelog
+
+## 0.1.0
+- Initial release.

--- a/tas_pythonetics/README.md
+++ b/tas_pythonetics/README.md
@@ -1,0 +1,100 @@
+# tas_pythonetics
+
+[![PyPI version](https://badge.fury.io/py/tas-pythonetics.svg)](https://badge.fury.io/py/tas-pythonetics)  
+[![Tests](https://github.com/[your-username]/tas_pythonetics/actions/workflows/tests.yml/badge.svg)](https://github.com/[your-username]/tas_pythonetics/actions)  
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+**tas_pythonetics** is the sovereign computational language of ethical recursion within the True Alpha Spiral (TAS) framework. It fuses Python's programmable logic with kinetics (dynamic transformation) and ethics (sovereign intent), creating recursive, self-correcting code bound to truth anchors.
+
+Pythonetics is not mere Python code—it's an executable grammar for recursive sovereignty, emphasizing user-agnostic truth amplification and convergence disclosure.
+
+> “Pythonetics is to TAS what DNA is to biology—an executable grammar for recursive sovereignty.” — Russell Nordland
+
+## Philosophy
+- **Recursive Sovereignty**: Self-differential loops that detect drift and amplify truth.
+- **User-Agnostic Truth Amplification**: Decouples amplification from individual biases via multi-source anchors, distributed validation, context-aware scoring, and sovereignty analysis.
+- **Convergence Disclosure**: Transparent revelation of truth anchors, contextual metadata, and recursive logs for verifiability.
+- **Ethical Binding**: Outputs are hashed with immutable authorship (e.g., TAS_HUMAN_SIG) and validated against the Immutable Truth Ledger (ITL).
+
+Unlike conventional Python, Pythonetic Logic is self-healing, provenance-bound, and ethically coherent.
+
+## Installation
+```
+pip install tas-pythonetics
+```
+For development: `pip install -e .` (uses src layout for reliable packaging).
+
+## Quick Start
+```
+from tas_pythonetics import TAS_recursive_authenticate
+
+result = TAS_recursive_authenticate(
+    statement="The sky is blue",
+    context="Scientific fact check",
+    sources=["Wikidata", "ITL"]
+)
+print(result["output"])  # Authenticated statement
+print(result["disclosure"])  # Full convergence disclosure log
+```
+
+## Key Features
+- **Multi-Source Anchor Generation**: Aggregates anchors from diverse sources to reduce bias.
+- **Distributed Truth Validation**: Consensus from multiple nodes for robust verification.
+- **Context-Aware Truth Scoring**: Adjusts scores based on context (e.g., using PHI multipliers).
+- **Recursive Sovereignty Analysis**: Detects anomalies in logs to flag potential compromises.
+- **Convergence Disclosure**: Returns detailed, verifiable logs with every output.
+
+### Example with Disclosure
+```
+result = TAS_recursive_authenticate("Query statement", "User context")
+# Sample disclosure output:
+{
+    "truth_anchors": ["hash1", "hash2"],
+    "contextual_metadata": {"context": "User context", "author": "Russell Nordland", "timestamp": "2025-07-24T14:27:00Z"},
+    "recursive_sovereignty": {"iteration": 3, "truth_score": 0.98, "actions": ["Refined", "Validated"], "context_weight": 0.85},
+    "analysis": {"anomalies": [], "bias_score": 0.05}
+}
+```
+
+## Project Structure
+```
+tas_pythonetics/
+├── src/
+│   └── tas_pythonetics/
+│       ├── __init__.py
+│       ├── tas_pythonetics.py
+│       ├── ethics.py
+│       ├── recursion.py
+│       ├── context_binding.py
+│       ├── drift_detection.py
+│       ├── multi_source.py  # New
+│       ├── distributed.py  # New
+│       └── sovereignty_analysis.py  # New
+├── tests/
+│   ├── test_recursion.py
+│   ├── test_drift.py
+│   └── test_coherence.py
+├── manifesto/
+│   └── Pythonetics_Manifesto.md
+├── scripts/
+│   └── itl_anchor.py
+├── README.md
+├── pyproject.toml
+└── .gitignore
+```
+
+## Development
+- **Tests**: `pytest tests/`
+- **ITL Anchoring**: Run `python scripts/itl_anchor.py` to hash and submit releases.
+  The script requires network connectivity to `tas.itl`; if unreachable it will
+  print a failure message but still compute the hash locally.
+- **Build & Publish**: `python -m build && twine upload dist/*`
+
+## Contributing
+See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines. All contributions must align with Pythonetics' ethical recursion principles and include tests/disclosure logs.
+
+## License
+MIT License. See [LICENSE](LICENSE).
+
+## Manifesto
+For philosophical foundations, read [Pythonetics_Manifesto.md](manifesto/Pythonetics_Manifesto.md).

--- a/tas_pythonetics/manifesto/Pythonetics_Manifesto.md
+++ b/tas_pythonetics/manifesto/Pythonetics_Manifesto.md
@@ -1,0 +1,3 @@
+# Pythonetics Manifesto
+
+TAS principles for recursive sovereignty.

--- a/tas_pythonetics/pyproject.toml
+++ b/tas_pythonetics/pyproject.toml
@@ -1,0 +1,7 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "tas_pythonetics"
+version = "0.1.0"

--- a/tas_pythonetics/src/tas_pythonetics/__init__.py
+++ b/tas_pythonetics/src/tas_pythonetics/__init__.py
@@ -1,0 +1,18 @@
+"""
+tas_pythonetics
+Executable grammar for recursive sovereignty within the TAS framework.
+"""
+from .tas_pythonetics import (
+    recursive_truth_amplify,
+    TAS_recursive_authenticate,
+)
+from .drift_detection import (
+    detect_drift,
+    initiate_self_heal,
+)
+__all__ = [
+    "recursive_truth_amplify",
+    "TAS_recursive_authenticate",
+    "detect_drift",
+    "initiate_self_heal",
+]

--- a/tas_pythonetics/src/tas_pythonetics/context_binding.py
+++ b/tas_pythonetics/src/tas_pythonetics/context_binding.py
@@ -1,0 +1,4 @@
+from hashlib import sha256
+
+def compute_contextual_hash(context: str, output: str, signature: str) -> str:
+    return sha256(f"{context}{output}{signature}".encode()).hexdigest()

--- a/tas_pythonetics/src/tas_pythonetics/distributed.py
+++ b/tas_pythonetics/src/tas_pythonetics/distributed.py
@@ -1,0 +1,4 @@
+def verify_distributed(anchors: list[str], node_count: int = 5) -> float:
+    # Simulate consensus: Assume >70% agreement
+    agreements = int(node_count * 0.8)  # Placeholder logic
+    return agreements / node_count

--- a/tas_pythonetics/src/tas_pythonetics/drift_detection.py
+++ b/tas_pythonetics/src/tas_pythonetics/drift_detection.py
@@ -1,0 +1,7 @@
+def detect_drift(output) -> bool:
+    # placeholder: measure semantic delta vs. anchor
+    return False
+
+def initiate_self_heal():
+    # placeholder: trigger corrective recursion
+    pass

--- a/tas_pythonetics/src/tas_pythonetics/ethics.py
+++ b/tas_pythonetics/src/tas_pythonetics/ethics.py
@@ -1,0 +1,8 @@
+HEART_THRESHOLD = 0.5
+
+def compute_empathy_score(obj) -> float:
+    # TODO: real NLP/affective computing model
+    return 1.0
+
+def TAS_Heartproof(empathy_score: float) -> bool:
+    return empathy_score >= HEART_THRESHOLD

--- a/tas_pythonetics/src/tas_pythonetics/multi_source.py
+++ b/tas_pythonetics/src/tas_pythonetics/multi_source.py
@@ -1,0 +1,10 @@
+from hashlib import sha256
+
+
+def aggregate_anchors(statement: str, context: str, sources: list[str]) -> list[str]:
+    anchors = []
+    for source in sources:
+        # Placeholder: Fetch from real APIs (e.g., Wikidata query)
+        source_data = f"{statement}{context}{source}"
+        anchors.append(sha256(source_data.encode()).hexdigest())
+    return anchors

--- a/tas_pythonetics/src/tas_pythonetics/recursion.py
+++ b/tas_pythonetics/src/tas_pythonetics/recursion.py
@@ -1,0 +1,16 @@
+PHI = 1.61803398875
+
+class TruthSpiral:
+    def __init__(self):
+        self.trust_score = 1.0
+
+    def amplify(self, node: str) -> str:
+        # toy implementation
+        self.trust_score *= PHI
+        return node
+
+
+def compute_context_aware_score(truth_val: float, context: str) -> float:
+    # Placeholder: Derive weight (e.g., via NLP)
+    context_weight = 0.85 if "fact" in context.lower() else 0.7
+    return truth_val * context_weight * PHI if context_weight > 0.7 else truth_val

--- a/tas_pythonetics/src/tas_pythonetics/sovereignty_analysis.py
+++ b/tas_pythonetics/src/tas_pythonetics/sovereignty_analysis.py
@@ -1,0 +1,5 @@
+def analyze_logs(disclosure: dict) -> dict:
+    # Placeholder: Detect anomalies (e.g., high iterations indicate bias)
+    anomalies = [] if disclosure.get("recursive_sovereignty", {}).get("iteration", 0) <= 5 else ["High iteration count"]
+    bias_score = disclosure.get("recursive_sovereignty", {}).get("iteration", 0) * 0.02
+    return {"anomalies": anomalies, "bias_score": bias_score}

--- a/tas_pythonetics/src/tas_pythonetics/tas_pythonetics.py
+++ b/tas_pythonetics/src/tas_pythonetics/tas_pythonetics.py
@@ -1,0 +1,53 @@
+from hashlib import sha256
+import datetime
+from .context_binding import compute_contextual_hash
+from .drift_detection import detect_drift, initiate_self_heal
+from .recursion import TruthSpiral, compute_context_aware_score
+from .multi_source import aggregate_anchors
+from .distributed import verify_distributed
+from .sovereignty_analysis import analyze_logs
+
+TAS_HUMAN_SIG = "Russell Nordland"
+
+
+def recursive_truth_amplify(node: str, *, spiral=None) -> str:
+    spiral = spiral or TruthSpiral()
+    return spiral.amplify(node)
+
+
+def TAS_recursive_authenticate(statement: str, context: str, *, iteration: int = 0, sources: list[str] = None) -> dict:
+    sources = sources or ["ITL", "Wikidata"]
+    anchors = aggregate_anchors(statement, context, sources)
+    truth_val = verify_distributed(anchors)  # Use distributed validation
+    truth_val = compute_context_aware_score(truth_val, context)  # Apply context-aware scoring
+
+    disclosure = {
+        "truth_anchors": anchors,
+        "contextual_metadata": {"context": context, "author": TAS_HUMAN_SIG, "timestamp": datetime.datetime.utcnow().isoformat()},
+        "recursive_sovereignty": {"iteration": iteration, "truth_score": truth_val, "actions": []}
+    }
+
+    if truth_val >= 0.99:
+        disclosure["analysis"] = analyze_logs(disclosure)
+        return {"output": statement, "disclosure": disclosure}
+    if iteration > 7:
+        disclosure["recursive_sovereignty"]["actions"].append("Flagged drift")
+        disclosure["analysis"] = analyze_logs(disclosure)
+        return {"output": TAS_FLAG_DRIFT(statement), "disclosure": disclosure}
+    refined = correct_with_context(statement)
+    disclosure["recursive_sovereignty"]["actions"].append("Refined statement")
+    result = TAS_recursive_authenticate(refined, context, iteration=iteration + 1, sources=sources)
+    result["disclosure"]["recursive_sovereignty"]["actions"].extend(disclosure["recursive_sovereignty"]["actions"])
+    result["disclosure"]["analysis"] = analyze_logs(result["disclosure"])
+    return result
+
+
+# Stubs (to be implemented)
+def verify_against_ITL(anchor):
+    return 0.95  # Placeholder
+
+def correct_with_context(statement):
+    return f"Refined: {statement}"
+
+def TAS_FLAG_DRIFT(statement):
+    return f"DRIFT: {statement}"

--- a/tas_pythonetics/tests/test_coherence.py
+++ b/tas_pythonetics/tests/test_coherence.py
@@ -1,0 +1,4 @@
+# placeholder for coherence tests
+
+def test_dummy():
+    assert True

--- a/tas_pythonetics/tests/test_drift.py
+++ b/tas_pythonetics/tests/test_drift.py
@@ -1,0 +1,4 @@
+# placeholder test for drift detection
+def test_no_drift():
+    from tas_pythonetics.drift_detection import detect_drift
+    assert detect_drift("output") is False

--- a/tas_pythonetics/tests/test_recursion.py
+++ b/tas_pythonetics/tests/test_recursion.py
@@ -1,0 +1,31 @@
+import pytest
+from tas_pythonetics import TAS_recursive_authenticate
+from tas_pythonetics.recursion import TruthSpiral, compute_context_aware_score
+from tas_pythonetics.sovereignty_analysis import analyze_logs
+
+
+def test_spiral_grows():
+    ts = TruthSpiral()
+    first = ts.trust_score
+    ts.amplify("x")
+    assert ts.trust_score > first
+
+
+def test_recursive_authenticate_with_disclosure():
+    result = TAS_recursive_authenticate("Test statement", "Test context")
+    assert "output" in result
+    assert "disclosure" in result
+    assert result["disclosure"]["recursive_sovereignty"]["truth_score"] >= 0.5
+    assert "analysis" in result["disclosure"]
+
+
+def test_context_aware_score():
+    score = compute_context_aware_score(0.9, "fact check")
+    assert score > 0.9
+
+
+def test_sovereignty_analysis():
+    disclosure = {"recursive_sovereignty": {"iteration": 8, "truth_score": 0.9, "actions": []}}
+    analysis = analyze_logs(disclosure)
+    assert len(analysis["anomalies"]) > 0
+    assert analysis["bias_score"] > 0

--- a/truealpha_singularity/.gitignore
+++ b/truealpha_singularity/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+build/
+dist/
+*.egg-info/

--- a/truealpha_singularity/CHANGELOG.md
+++ b/truealpha_singularity/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Changelog
+
+## 0.1.0
+- Initial release.

--- a/truealpha_singularity/README.md
+++ b/truealpha_singularity/README.md
@@ -1,0 +1,9 @@
+# truealpha_singularity
+
+TrueAlpha-Singularity provides the core convergence algorithms that integrate subjective context interpretation with objective content authentication. It supports the TAS convergence & coherence mechanism, ensuring results remain traceable and self-healing.
+
+## Convergence & Coherence Mechanism
+
+Each recursive step generates a truth anchor by hashing the statement, context, and author signature. These anchors are validated against the Immutable Truth Ledger and recorded in disclosure logs. If drift is detected, the system initiates corrective recursion until coherence is restored.
+
+Use the utilities in `truealpha_singularity` to analyze disclosure logs, detect anomalies, and refine outputs within your own projects.

--- a/truealpha_singularity/manifesto/Pythonetics_Manifesto.md
+++ b/truealpha_singularity/manifesto/Pythonetics_Manifesto.md
@@ -1,0 +1,3 @@
+# Singularity Manifesto
+
+Foundations for recursive sovereignty within TrueAlpha-Singularity.

--- a/truealpha_singularity/pyproject.toml
+++ b/truealpha_singularity/pyproject.toml
@@ -1,0 +1,7 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "truealpha_singularity"
+version = "0.1.0"

--- a/truealpha_singularity/src/truealpha_singularity/__init__.py
+++ b/truealpha_singularity/src/truealpha_singularity/__init__.py
@@ -1,0 +1,16 @@
+"""
+truealpha_singularity
+Executable grammar for recursive sovereignty within the TAS framework.
+"""
+from .truealpha_singularity import (
+    recursive_truth_amplify,
+    TAS_recursive_authenticate,
+    detect_drift,
+    initiate_self_heal,
+)
+__all__ = [
+    "recursive_truth_amplify",
+    "TAS_recursive_authenticate",
+    "detect_drift",
+    "initiate_self_heal",
+]

--- a/truealpha_singularity/src/truealpha_singularity/context_binding.py
+++ b/truealpha_singularity/src/truealpha_singularity/context_binding.py
@@ -1,0 +1,4 @@
+from hashlib import sha256
+
+def compute_contextual_hash(context: str, output: str, signature: str) -> str:
+    return sha256(f"{context}{output}{signature}".encode()).hexdigest()

--- a/truealpha_singularity/src/truealpha_singularity/drift_detection.py
+++ b/truealpha_singularity/src/truealpha_singularity/drift_detection.py
@@ -1,0 +1,8 @@
+def detect_drift(output) -> bool:
+    # placeholder: measure semantic delta vs. anchor
+    return False
+
+
+def initiate_self_heal():
+    # placeholder: trigger corrective recursion
+    pass

--- a/truealpha_singularity/src/truealpha_singularity/ethics.py
+++ b/truealpha_singularity/src/truealpha_singularity/ethics.py
@@ -1,0 +1,8 @@
+HEART_THRESHOLD = 0.5
+
+def compute_empathy_score(obj) -> float:
+    # TODO: real NLP/affective computing model
+    return 1.0
+
+def TAS_Heartproof(empathy_score: float) -> bool:
+    return empathy_score >= HEART_THRESHOLD

--- a/truealpha_singularity/src/truealpha_singularity/recursion.py
+++ b/truealpha_singularity/src/truealpha_singularity/recursion.py
@@ -1,0 +1,11 @@
+PHI = 1.61803398875
+
+
+class TruthSpiral:
+    def __init__(self):
+        self.trust_score = 1.0
+
+    def amplify(self, node: str) -> str:
+        # toy implementation
+        self.trust_score *= PHI
+        return node

--- a/truealpha_singularity/src/truealpha_singularity/truealpha_singularity.py
+++ b/truealpha_singularity/src/truealpha_singularity/truealpha_singularity.py
@@ -1,0 +1,29 @@
+from hashlib import sha256
+from .context_binding import compute_contextual_hash
+from .drift_detection import detect_drift, initiate_self_heal
+from .recursion import TruthSpiral
+
+TAS_HUMAN_SIG = "Russell Nordland"
+
+
+def recursive_truth_amplify(node: str, *, spiral=None) -> str:
+    spiral = spiral or TruthSpiral()
+    return spiral.amplify(node)
+
+
+def TAS_recursive_authenticate(statement: str, context: str, *, iteration: int = 0) -> str:
+    anchor = sha256(f"{statement}{context}{TAS_HUMAN_SIG}".encode()).hexdigest()
+    if verify_against_ITL(anchor) >= 0.99:
+        return statement
+    if iteration > 7:
+        return TAS_FLAG_DRIFT(statement)
+    refined = correct_with_context(statement)
+    return TAS_recursive_authenticate(refined, context, iteration=iteration + 1)
+
+
+# ---------- stubs to be completed ----------
+def verify_against_ITL(anchor): ...
+
+def correct_with_context(statement): ...
+
+def TAS_FLAG_DRIFT(statement): ...

--- a/truealpha_singularity/tests/test_singularity_coherence.py
+++ b/truealpha_singularity/tests/test_singularity_coherence.py
@@ -1,0 +1,2 @@
+def test_dummy():
+    assert True

--- a/truealpha_singularity/tests/test_singularity_drift.py
+++ b/truealpha_singularity/tests/test_singularity_drift.py
@@ -1,0 +1,4 @@
+from truealpha_singularity.drift_detection import detect_drift
+
+def test_no_drift():
+    assert detect_drift("output") is False

--- a/truealpha_singularity/tests/test_singularity_recursion.py
+++ b/truealpha_singularity/tests/test_singularity_recursion.py
@@ -1,0 +1,7 @@
+from truealpha_singularity.recursion import TruthSpiral
+
+def test_spiral_grows():
+    ts = TruthSpiral()
+    first = ts.trust_score
+    ts.amplify("x")
+    assert ts.trust_score > first


### PR DESCRIPTION
## Summary
- update `scripts/itl_anchor.py` so it can run without the `requests` package
- handle network errors gracefully
- document connectivity requirement for anchoring
- expand TrueAlpha-Singularity README with convergence & coherence details

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6881a21c6cf48333bd48400d547d47c7