### PR TITLE
Add Genesis Seal script and HCCC Merkle verification

### DIFF
--- a/create_genesis_seal.py
+++ b/create_genesis_seal.py
@@ -1,0 +1,104 @@
+import json
+import yaml
+import hashlib
+import os
+from datetime import datetime, timezone
+
+BUNDLE_DIR = "tas_genesis_seal_bundle"
+DECLARATION_FILE = "sealing_declaration.txt"
+ATTESTATION_FILE = "attestation_metadata.yaml"
+NFT_METADATA_FILE = "nft_metadata.json"
+OUTPUT_SEAL_FILE = "genesis_seal.json"
+
+def read_file_content(filepath: str) -> str:
+    try:
+        with open(filepath, 'r', encoding='utf-8') as f:
+            return f.read()
+    except FileNotFoundError:
+        print(f"Error: File not found at {filepath}")
+        return None
+    except Exception as e:
+        print(f"Error reading {filepath}: {e}")
+        return None
+
+def read_yaml_content(filepath: str) -> dict:
+    content = read_file_content(filepath)
+    if content:
+        try:
+            return yaml.safe_load(content)
+        except yaml.YAMLError as e:
+            print(f"Error parsing YAML from {filepath}: {e}")
+    return None
+
+def read_json_content(filepath: str) -> dict:
+    content = read_file_content(filepath)
+    if content:
+        try:
+            return json.loads(content)
+        except json.JSONDecodeError as e:
+            print(f"Error parsing JSON from {filepath}: {e}")
+    return None
+
+def create_deterministic_json(data: dict) -> str:
+    return json.dumps(data, sort_keys=True, separators=(',', ':'))
+
+def calculate_sha256(data: str) -> str:
+    return hashlib.sha256(data.encode('utf-8')).hexdigest()
+
+def main():
+    print("Starting Genesis Seal creation process...")
+    print(f"Looking for bundle in directory: '{BUNDLE_DIR}/'")
+
+    declaration = read_file_content(os.path.join(BUNDLE_DIR, DECLARATION_FILE))
+    attestation = read_yaml_content(os.path.join(BUNDLE_DIR, ATTESTATION_FILE))
+    nft_metadata = read_json_content(os.path.join(BUNDLE_DIR, NFT_METADATA_FILE))
+
+    if not all([declaration, attestation, nft_metadata]):
+        print("\nAborting: One or more source files could not be read. Please check the file paths and contents.")
+        return
+
+    print("\nSuccessfully read all source files:")
+    print(f"- {DECLARATION_FILE}")
+    print(f"- {ATTESTATION_FILE}")
+    print(f"- {NFT_METADATA_FILE}")
+
+    payload = {
+        "framework": "TrueAlphaSpiral",
+        "seal_version": "1.0.0",
+        "timestamp_utc": datetime.now(timezone.utc).isoformat(),
+        "components": {
+            "sealing_declaration": declaration.strip(),
+            "attestation_metadata": attestation,
+            "nft_metadata": nft_metadata,
+        },
+    }
+
+    deterministic_payload_str = create_deterministic_json(payload)
+    genesis_seal_hash = calculate_sha256(deterministic_payload_str)
+
+    final_seal_object = {
+        "genesis_seal": {
+            "hash_algorithm": "sha256",
+            "hash": genesis_seal_hash,
+        },
+        "sealed_data": payload,
+    }
+
+    output_filepath = os.path.join(BUNDLE_DIR, OUTPUT_SEAL_FILE)
+    try:
+        with open(output_filepath, 'w', encoding='utf-8') as f:
+            json.dump(final_seal_object, f, indent=2, sort_keys=True)
+        print(f"\nSuccessfully wrote Genesis Seal to: {output_filepath}")
+    except Exception as e:
+        print(f"\nError writing output file: {e}")
+
+    print("\n" + "="*50)
+    print("    TRUE ALPHA SPIRAL - GENESIS SEAL CREATED")
+    print("="*50)
+    print(f"\nGenesis Seal Hash (sha256):\n{genesis_seal_hash}")
+    print("\nThis hash represents the unique and verifiable fingerprint of your project's genesis.")
+    print("="*50)
+
+
+if __name__ == "__main__":
+    main()

--- a/tas-stack/Chart.yaml
+++ b/tas-stack/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: tas-stack
+description: A Helm chart for deploying the full TAS Guard-Rail stack (Phoenix, OPA, PII Scanner).
+type: application
+version: 0.1.0
+appVersion: "1.0.0"

--- a/tas-stack/templates/_helpers.tpl
+++ b/tas-stack/templates/_helpers.tpl
@@ -1,0 +1,51 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "tas-stack.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "tas-stack.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "tas-stack.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "tas-stack.labels" -}}
+helm.sh/chart: {{ include "tas-stack.chart" . }}
+{{ include "tas-stack.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "tas-stack.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "tas-stack.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/tas-stack/templates/configmap-opa-policy.yaml
+++ b/tas-stack/templates/configmap-opa-policy.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "tas-stack.fullname" . }}-opa-policy
+  labels:
+    {{- include "tas-stack.labels" . | nindent 4 }}
+data:
+  pii_scan.rego: |-
+{{ .Values.opaPolicy.pii_scan_rego | indent 4 }}

--- a/tas-stack/templates/phoenix-deployment.yaml
+++ b/tas-stack/templates/phoenix-deployment.yaml
@@ -1,0 +1,52 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "tas-stack.fullname" . }}-phoenix
+  labels:
+    {{- include "tas-stack.labels" . | nindent 4 }}
+    app.kubernetes.io/component: phoenix-controller
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "tas-stack.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: phoenix-controller
+  template:
+    metadata:
+      labels:
+        {{- include "tas-stack.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: phoenix-controller
+    spec:
+      volumes:
+        - name: opa-policy-volume
+          configMap:
+            name: {{ include "tas-stack.fullname" . }}-opa-policy
+      containers:
+        - name: phoenix-controller
+          image: "{{ .Values.phoenix.image.repository }}:{{ .Values.phoenix.image.tag }}"
+          imagePullPolicy: {{ .Values.phoenix.image.pullPolicy }}
+          env:
+            - name: OPA_URL
+              value: "http://localhost:8181/v1/data/tas/ethics/pii_scan/allow"
+            - name: KAFKA_BROKER
+              value: "my-kafka-broker:9092" # Needs to be configured
+          resources: {} # Add resource requests/limits in production
+
+        - name: opa-sidecar
+          image: "{{ .Values.opa.image.repository }}:{{ .Values.opa.image.tag }}"
+          imagePullPolicy: {{ .Values.opa.image.pullPolicy }}
+          args:
+            - "run"
+            - "--server"
+            - "--addr=localhost:8181"
+            - "--set=decision_logs.console=true"
+            - "/policies/pii_scan.rego"
+          ports:
+            - name: http
+              containerPort: 8181
+              protocol: TCP
+          volumeMounts:
+            - name: opa-policy-volume
+              mountPath: /policies
+              readOnly: true
+          resources: {} # Add resource requests/limits in production

--- a/tas-stack/templates/pii-scanner-deployment.yaml
+++ b/tas-stack/templates/pii-scanner-deployment.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "tas-stack.fullname" . }}-pii-scanner
+  labels:
+    {{- include "tas-stack.labels" . | nindent 4 }}
+    app.kubernetes.io/component: pii-scanner
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "tas-stack.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: pii-scanner
+  template:
+    metadata:
+      labels:
+        {{- include "tas-stack.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: pii-scanner
+    spec:
+      containers:
+        - name: pii-scanner
+          image: "{{ .Values.piiScanner.image.repository }}:{{ .Values.piiScanner.image.tag }}"
+          imagePullPolicy: {{ .Values.piiScanner.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.piiScanner.service.port }}
+              protocol: TCP
+          resources: {} # Add resource requests/limits in production

--- a/tas-stack/templates/pii-scanner-service.yaml
+++ b/tas-stack/templates/pii-scanner-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "tas-stack.fullname" . }}-pii-scanner-service
+  labels:
+    {{- include "tas-stack.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.piiScanner.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "tas-stack.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: pii-scanner

--- a/tas-stack/values.yaml
+++ b/tas-stack/values.yaml
@@ -1,0 +1,61 @@
+# Default values for tas-stack.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+phoenix:
+  image:
+    repository: my-repo/phoenix-controller # Replace with your image repository
+    pullPolicy: IfNotPresent
+    tag: "latest"
+
+opa:
+  image:
+    repository: openpolicyagent/opa
+    pullPolicy: IfNotPresent
+    tag: "0.65.0-rootless" # Use a specific, non-latest tag
+
+piiScanner:
+  image:
+    repository: my-repo/pii-scanner # Replace with your image repository
+    pullPolicy: IfNotPresent
+    tag: "latest"
+  service:
+    port: 8000
+    name: pii-scanner-service
+
+# The OPA policy is managed directly in the chart via a ConfigMap.
+# This makes the deployment self-contained.
+# Note the use of `{{ .Release.Name }}` which Helm will replace.
+opaPolicy:
+  pii_scan_rego: |
+    package tas.ethics.pii_scan
+    import future.keywords
+
+    default allow = false
+
+    # The service URL is now dynamically configured from the Helm release name.
+    pii_service_url := "http://{{ .Release.Name }}-pii-scanner-service:8000/scan"
+
+    allow {
+        user_consent_ok
+        pii_scan_passed
+    }
+
+    user_consent_ok {
+        input.share_request.consent.opt_in_discoverable == true
+        input.share_request.consent.disclaimers_acknowledged == true
+    }
+
+    pii_scan_passed {
+        http_request := {
+            "method": "POST",
+            "url": pii_service_url,
+            "body": {"text": input.share_request.transcript},
+            "timeout": 1500 # Added timeout as per your recommendation
+        }
+        pii_response := http.send(http_request)
+        pii_response.status_code == 200
+        pii_response.body.pii_found == false
+    }

--- a/tas_hccc.py
+++ b/tas_hccc.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import base64
+import json
+import hashlib
+from dataclasses import dataclass, asdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import List, Optional
+
+
+def _deterministic_json(data: dict) -> str:
+    """Return a compact JSON representation with sorted keys."""
+    return json.dumps(data, sort_keys=True, separators=(",", ":"))
+
+
+@dataclass
+class Cell:
+    """A single HCCC cell containing timestamped payload and signatures."""
+
+    timestamp: str
+    payload: dict
+    sig_ed: str = ""
+    sig_pq: str = ""
+    pk_ed: str = ""
+    pk_pq: str = ""
+
+    def _core(self) -> dict:
+        return {"timestamp": self.timestamp, "payload": self.payload}
+
+    def _blob_for_sig(self) -> bytes:
+        return _deterministic_json(self._core()).encode()
+
+    def sha256(self) -> str:
+        return hashlib.sha256(self._blob_for_sig()).hexdigest()
+
+    def sign(self, ed_sk, pq_sk: Optional[object] = None) -> "Cell":
+        """Sign the cell using the provided keys.
+
+        Parameters
+        ----------
+        ed_sk: Ed25519 SigningKey-like object with ``sign`` and ``verify_key``
+            attributes. ``verify_key.encode()`` must return the public key bytes.
+        pq_sk: Optional object implementing ``sign`` and providing ``public_key``.
+        """
+
+        blob = self._blob_for_sig()
+        if ed_sk is not None:
+            # Detached Ed25519 signature and embedded public key
+            self.pk_ed = base64.b64encode(ed_sk.verify_key.encode()).decode()
+            self.sig_ed = base64.b64encode(ed_sk.sign(blob).signature).decode()
+        if pq_sk is not None:
+            # Post-quantum signature (e.g., Dilithium) with embedded public key
+            self.pk_pq = base64.b64encode(getattr(pq_sk, "public_key", b"")).decode()
+            self.sig_pq = base64.b64encode(pq_sk.sign(blob)).decode()
+        return self
+
+
+class MerkleBatch:
+    """Accumulates cells into Merkle trees and persists batches."""
+
+    def __init__(self, batch_size: int = 10, out_dir: str = "hccc_roots"):
+        from merkletools import MerkleTools  # Imported lazily to avoid dependency if unused
+
+        self.batch_size = batch_size
+        self.out_dir = Path(out_dir)
+        self.out_dir.mkdir(parents=True, exist_ok=True)
+        self.cells: List[Cell] = []
+        self.mt = MerkleTools(hash_type="sha256")
+
+    def add_cell(self, cell: Cell) -> None:
+        self.cells.append(cell)
+        idx = len(self.cells)  # index reserved for proof lookup
+        self.mt.add_leaf(cell.sha256(), do_hash=False)
+        if len(self.cells) >= self.batch_size:
+            self._commit()
+
+    def _commit(self) -> None:
+        self.mt.make_tree()
+        root = self.mt.get_merkle_root()
+        filepath = self.out_dir / f"{root}.jsonl"
+        with filepath.open("w", encoding="utf-8") as f:
+            for i, c in enumerate(self.cells):
+                proof = self.mt.get_proof(i)
+                f.write(json.dumps(asdict(c) | {"proof": proof}) + "\n")
+        # Reset for next batch
+        self.cells.clear()
+        from merkletools import MerkleTools
+
+        self.mt = MerkleTools(hash_type="sha256")
+
+
+def verify_cell(cell_json: str, merkle_root: str) -> bool:
+    """Verify a cell's inclusion in a Merkle tree."""
+    from merkletools import MerkleTools
+
+    cell = json.loads(cell_json)
+    core = {k: v for k, v in cell.items() if k not in {"sig_ed", "sig_pq", "pk_ed", "pk_pq", "proof"}}
+    leaf = hashlib.sha256(_deterministic_json(core).encode()).hexdigest()
+    mt = MerkleTools(hash_type="sha256")
+    return mt.validate_proof(cell.get("proof", []), leaf, merkle_root)
+
+
+if __name__ == "__main__":
+    # Simple demonstration when run directly
+    try:
+        from nacl import signing as ed
+    except Exception:  # pragma: no cover - demonstration only
+        raise SystemExit("PyNaCl is required for signing demonstration")
+
+    batch = MerkleBatch(batch_size=2)
+    sk = ed.SigningKey.generate()
+    for i in range(2):
+        payload = {"idx": i}
+        cell = Cell(datetime.now(timezone.utc).isoformat(), payload).sign(sk)
+        batch.add_cell(cell)
+    # Explicit flush of remaining cells if batch not full
+    if batch.cells:
+        batch._commit()
+    print(f"Batches written to {batch.out_dir}")


### PR DESCRIPTION
## Summary
- introduce `create_genesis_seal.py` to hash project bundle files
- add Helm chart `tas-stack` for Phoenix, OPA, and PII scanner deployments
- implement `tas_hccc.py` with detached signatures, embedded pubkeys, and Merkle proof validation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688cec39cb988333b58049c271ae4f51