### PR TITLE
Add PQFA attestation bundle artifacts

### DIFF
--- a/attestations/PQFA_Attestation_Bundle_v1.json
+++ b/attestations/PQFA_Attestation_Bundle_v1.json
@@ -1,0 +1,54 @@
+{
+  "bundle_header": ".tas_whitepaper",
+  "bundle_id": "PQFA_Attestation_Bundle_v1",
+  "standard": "TAS_MOBILE_SIG",
+  "title": "Post-Quantum Fortress Architecture: A Framework for Mobile Sovereignty Anchors and Integrity Interfaces in the Civic OS Paradigm",
+  "public_briefing_hash_entry": {
+    "algorithm": "SHA-256",
+    "digest": "e5a5e4cfbafc1f2aef15dea27136c893147683b934f4f3d703322ecd09121538"
+  },
+  "tas_seal_metadata": {
+    "sealed": true,
+    "ledger_system": "Immutable Truth Ledger (ITL)",
+    "provenance_scope": [
+      "Immutable provenance tracking",
+      "Ledger verification in TAS_DNA",
+      "PQC co-signature workflows",
+      "Genesis Mission compliance archives"
+    ]
+  },
+  "signature_schema": {
+    "digest_algorithm": "SHA-256",
+    "pqc_signature_algorithm": "ML-DSA (FIPS 204)",
+    "ml_dsa_signature_placeholder": {
+      "status": "pending",
+      "slot": "ml_dsa_sig_01",
+      "signature": null,
+      "public_key": null
+    }
+  },
+  "genesis_anchor": {
+    "network": "Ethereum",
+    "block": 19484201,
+    "label": "Genesis Anchor"
+  },
+  "co_signers": [
+    {
+      "name": "Russell Nordland",
+      "role": "TAS Architect & Steward",
+      "sig_type": "TAS_HUMAN_SIG",
+      "status": "Primary Signatory (Authenticated)"
+    },
+    {
+      "name": "Genesis Mission",
+      "role": "Federal Anchor",
+      "sig_type": "ASSP Compliance Seal",
+      "status": "Pending August 21, 2026 IOC"
+    }
+  ],
+  "ledger_commit": {
+    "entry_type": ".tas_whitepaper",
+    "timestamp_utc": "2026-02-10T00:00:00Z",
+    "comment": "Attestation payload prepared for co-signable ITL submission under TAS_MOBILE_SIG."
+  }
+}

--- a/attestations/PQFA_Attestation_Bundle_v1.md
+++ b/attestations/PQFA_Attestation_Bundle_v1.md
@@ -1,0 +1,42 @@
+# PQFA_Attestation_Bundle_v1
+
+## Bundle Header
+- `entry_type`: `.tas_whitepaper`
+- `standard`: `TAS_MOBILE_SIG`
+- `title`: `Post-Quantum Fortress Architecture: A Framework for Mobile Sovereignty Anchors and Integrity Interfaces in the Civic OS Paradigm`
+
+## Public Briefing Hash Entry
+- `algorithm`: `SHA-256`
+- `digest`: `e5a5e4cfbafc1f2aef15dea27136c893147683b934f4f3d703322ecd09121538`
+
+## TAS_Seal_Metadata
+- `sealed`: `true`
+- `ledger_system`: `Immutable Truth Ledger (ITL)`
+- `provenance_scope`:
+  - Immutable provenance tracking
+  - Ledger verification in TAS_DNA
+  - PQC co-signature workflows
+  - Genesis Mission compliance archives
+
+## Signature Schema
+- `digest_algorithm`: `SHA-256`
+- `pqc_signature_algorithm`: `ML-DSA (FIPS 204)`
+- `ml_dsa_signature_placeholder`:
+  - `status`: `pending`
+  - `slot`: `ml_dsa_sig_01`
+  - `signature`: `null`
+  - `public_key`: `null`
+
+## Genesis Anchor
+- `network`: `Ethereum`
+- `block`: `19,484,201`
+- `label`: `Genesis Anchor`
+
+## Co-Signers
+1. **Russell Nordland** — TAS Architect & Steward (`TAS_HUMAN_SIG`)
+2. **Genesis Mission** — Federal Anchor (`ASSP Compliance Seal`, pending August 21, 2026 IOC)
+
+## Ledger Commit
+- `entry_type`: `.tas_whitepaper`
+- `timestamp_utc`: `2026-02-10T00:00:00Z`
+- `comment`: `Attestation payload prepared for co-signable ITL submission under TAS_MOBILE_SIG.`


### PR DESCRIPTION
### Motivation
- Provide a machine-readable and human-readable attestation payload for the Post-Quantum Fortress Architecture (PQFA) to serve as a co-signable ITL submission with a `.tas_whitepaper` bundle header.
- Include core attestation fields required for TAS workflows such as a public briefing hash, TAS seal metadata, a placeholder ML-DSA signature slot, and a Genesis anchor reference.

### Description
- Added `attestations/PQFA_Attestation_Bundle_v1.json` containing the attestation payload with `bundle_header` set to `.tas_whitepaper`, `public_briefing_hash_entry` (SHA-256 digest), `tas_seal_metadata`, `signature_schema` with an ML-DSA placeholder, and `genesis_anchor` referencing Ethereum block `19,484,201`.
- Added `attestations/PQFA_Attestation_Bundle_v1.md` as a human-readable mirror of the JSON payload for review and submission guidance.
- Ensured the JSON includes `co_signers` and `ledger_commit` fields to capture signatory metadata and commit context.

### Testing
- Validated JSON syntax with `python -m json.tool attestations/PQFA_Attestation_Bundle_v1.json` which succeeded.
- Executed the repository test suite with `pytest -q` which completed successfully with `6 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b661d90f08333983000eb63af0e0d)