### PR TITLE
🧹 [code health improvement] Remove unused imports in citation.py

### DIFF
--- a/tas_pythonetics/src/tas_pythonetics/citation.py
+++ b/tas_pythonetics/src/tas_pythonetics/citation.py
@@ -1,7 +1,3 @@
-import json
-import os
-import sys
-
 # Simplified mock registry for the package, so we don't depend on external files for the basic logic
 MOCK_REGISTRY = {
     "citations": [
@@ -35,3 +31,5 @@ def cite_source(query: str, agent_id: str = "TAS_Agent") -> dict:
             }
         }
     return {"found": False, "error": "Query not found"}
+
+# Kinematic Identity Nonce: 55860

--- a/tas_pythonetics/src/tas_pythonetics/citation.py.tasmeta.json
+++ b/tas_pythonetics/src/tas_pythonetics/citation.py.tasmeta.json
@@ -1,12 +1,12 @@
 {
-  "id": "b92ec887e4ae91250e83b7062c541ccfb9c8e297380f23052d917aba0c66a957",
+  "id": "4c4ce34b9199490836f1033ed2f3a2e6264dfec1d2d8e975d34dd470791438f3",
   "type": "TasArtifact",
-  "form_id": "e413f04e13fe4b393ec8a15558fe42a7dd2a78153637659a055938c85d2c67d1",
+  "form_id": "2dc4e9c808fc926fe6e2be024eedd2b92c312bef47f528cb292b5d75f9911d25",
   "genome_id": "TAS_GENOME_V1",
-  "lineage_id": "b92ec887e4ae91250e83b7062c541ccfb9c8e297380f23052d917aba0c66a957",
+  "lineage_id": "4c4ce34b9199490836f1033ed2f3a2e6264dfec1d2d8e975d34dd470791438f3",
   "h_seed": "Russell Nordland",
-  "cert_id": "e68b06f3-4531-4057-b74c-ad7e2a97549b",
-  "timestamp": "2026-02-26T02:25:52.030438+00:00",
+  "cert_id": "9870e464-8165-4b03-9783-5b3f40510f57",
+  "timestamp": "2026-03-31T21:10:20.326867+00:00",
   "paradata_trail": [],
   "signatures": [
     {


### PR DESCRIPTION
🎯 **What:** The code health issue addressed was the presence of unused imports (`json`, `os`, and `sys`) in the file `tas_pythonetics/src/tas_pythonetics/citation.py`.

💡 **Why:** Removing these unused imports reduces code clutter, improves maintainability, and clarifies dependencies for anyone reading the code.

✅ **Verification:**
- Ran the specific test suite: `PYTHONPATH=$(pwd)/tas_pythonetics/src pytest tas_pythonetics/tests/`. All 71 tests passed.
- Verified the Kinematic Identity (Prime Invariant) of the modified file using `python3 tas_cli.py verify-identity`. The verification passed after finding and appending a valid nonce.
- Synchronized the artifact metadata using `python3 tas_cli.py sequence`.
- Confirmed the absence of the imports using `grep`.

✨ **Result:** The codebase is cleaner and follows the TAS framework's integrity requirements (Living Braid) while maintaining all existing functionality.

---
*PR created automatically by Jules for task [14339921383437842457](https://jules.google.com/task/14339921383437842457) started by @TrueAlpha-spiral*