### PR TITLE
🧹 [code health improvement] Remove unused import os in git_safety.py

### DIFF
--- a/tas_pythonetics/src/tas_pythonetics/git_safety.py
+++ b/tas_pythonetics/src/tas_pythonetics/git_safety.py
@@ -1,6 +1,5 @@
 import logging
 import subprocess
-import os
 import shlex
 
 # Configure logging

--- a/tas_pythonetics/src/tas_pythonetics/git_safety.py.tasmeta.json
+++ b/tas_pythonetics/src/tas_pythonetics/git_safety.py.tasmeta.json
@@ -1,12 +1,12 @@
 {
-  "id": "c6ac051eb00540e011d5e0c0534efc23f75a1d84ac597c407bd5063cc99b13eb",
+  "id": "87bd7584c919d10838cc772dd3950f8af503bf11567e4e2ba2b9dcfdc034eda7",
   "type": "TasArtifact",
-  "form_id": "d6281a1a3a495f4307d9ca916cceb0ad07c6d4f746fd4db333cf47ff71d92143",
+  "form_id": "edc02f8cd3229b124da31c9abc42f30ec0e2b33d38a027dd3907d2fb457a27b1",
   "genome_id": "TAS_GENOME_V1",
-  "lineage_id": "c6ac051eb00540e011d5e0c0534efc23f75a1d84ac597c407bd5063cc99b13eb",
+  "lineage_id": "87bd7584c919d10838cc772dd3950f8af503bf11567e4e2ba2b9dcfdc034eda7",
   "h_seed": "Russell Nordland",
-  "cert_id": "937eff9f-4702-4985-8adf-f5c4aa2eb456",
-  "timestamp": "2026-02-26T02:25:36.089575+00:00",
+  "cert_id": "1e6f360c-d105-451b-91f2-1c3b854b1644",
+  "timestamp": "2026-03-24T21:15:33.842367+00:00",
   "paradata_trail": [],
   "signatures": [
     {


### PR DESCRIPTION
🎯 **What:** Removed the unused `os` standard library import from `tas_pythonetics/src/tas_pythonetics/git_safety.py`.
💡 **Why:** This cleans up the code and improves maintainability by removing dead code.
✅ **Verification:**
- Ran `pytest tas_pythonetics/tests/test_git_safety.py` (Passed).
- Ran the full test suite (37 tests, all Passed).
- Updated TAS metadata for the modified file using `tas_cli.py sequence` to maintain the integrity manifold.
✨ **Result:** A cleaner and more maintainable `git_safety.py` with synchronized metadata.

---
*PR created automatically by Jules for task [15814175845251267054](https://jules.google.com/task/15814175845251267054) started by @TrueAlpha-spiral*