### PR TITLE
🧪 [testing improvement] Add tests for initiate_self_heal and fix case-sensitivity bug

### DIFF
--- a/tas_pythonetics/src/tas_pythonetics/drift_detection.py
+++ b/tas_pythonetics/src/tas_pythonetics/drift_detection.py
@@ -1,3 +1,5 @@
+import re
+
 FORBIDDEN_PATTERNS = ["hallucinate", "false", "lie"]
 
 def detect_drift(output: str, context: str = "") -> bool:
@@ -22,8 +24,8 @@ def initiate_self_heal(output: str) -> str:
     """
     healed = output
     for pattern in FORBIDDEN_PATTERNS:
-        if pattern in healed.lower():
-            healed = healed.replace(pattern, "[REDACTED]")
+        # Case-insensitive replacement
+        healed = re.sub(re.escape(pattern), "[REDACTED]", healed, flags=re.IGNORECASE)
 
     if "[HEALED]" not in healed:
         healed += " [HEALED]"

--- a/tas_pythonetics/tests/test_drift.py
+++ b/tas_pythonetics/tests/test_drift.py
@@ -15,3 +15,26 @@ def test_initiate_self_heal():
     healed = initiate_self_heal(output)
     assert "[REDACTED]" in healed
     assert "[HEALED]" in healed
+
+def test_initiate_self_heal_no_patterns():
+    output = "perfectly fine output"
+    healed = initiate_self_heal(output)
+    assert healed == "perfectly fine output [HEALED]"
+
+def test_initiate_self_heal_already_healed():
+    output = "this is a lie [HEALED]"
+    healed = initiate_self_heal(output)
+    assert healed.count("[HEALED]") == 1
+    assert "[REDACTED]" in healed
+
+def test_initiate_self_heal_multiple_patterns():
+    output = "a lie and a hallucinate"
+    healed = initiate_self_heal(output)
+    assert healed.count("[REDACTED]") == 2
+    assert "[HEALED]" in healed
+
+def test_initiate_self_heal_case_insensitivity():
+    output = "This is a LIE"
+    healed = initiate_self_heal(output)
+    assert "[REDACTED]" in healed
+    assert "[HEALED]" in healed


### PR DESCRIPTION
🎯 **What:** The testing gap for `initiate_self_heal` in `drift_detection.py` has been addressed.
📊 **Coverage:** 
- Input with no forbidden patterns (verifies `[HEALED]` tag is added).
- Input that already has the `[HEALED]` tag (verifies no duplication).
- Input with multiple different forbidden patterns (verifies all are redacted).
- Input with mixed-case forbidden patterns (verifies case-insensitive redaction).
✨ **Result:** Test coverage for `drift_detection.py` is significantly improved, and a case-sensitivity bug was identified and fixed.

---
*PR created automatically by Jules for task [4181570599778318201](https://jules.google.com/task/4181570599778318201) started by @TrueAlpha-spiral*