### PR TITLE
🔒 fix command injection in run_command

### DIFF
--- a/higgs bason DHSV1
+++ b/higgs bason DHSV1
@@ -53,6 +53,7 @@ Architect: Russell Nordland
 """
 
 import os
+import shlex
 import sys
 import time
 import json
@@ -98,7 +99,12 @@ def run_command(command, wait=True):
     """Run a command and optionally wait for it to complete."""
     log_message(f"Running command: {command}", BLUE)
     try:
-        process = subprocess.Popen(command, shell=True)
+        # Use shlex.split to safely parse the command string into a list
+        if isinstance(command, str):
+            args = shlex.split(command)
+        else:
+            args = command
+        process = subprocess.Popen(args, shell=False)
         if wait:
             process.wait()
             log_message(f"Command completed with exit code: {process.returncode}", GREEN if process.returncode == 0 else RED)


### PR DESCRIPTION
This PR addresses a command injection vulnerability in the `run_command` function within `higgs bason DHSV1`. By switching from `shell=True` to `shell=False` and using `shlex.split()` for argument parsing, we eliminate the risk of attackers injecting malicious commands through the shell interpreter.

### 🎯 What
Fixed a command injection vulnerability in the `run_command` function.

### ⚠️ Risk
An attacker could potentially execute arbitrary commands on the host system by providing a crafted string to `run_command`, leading to unauthorized access, data loss, or system compromise.

### 🛡️ Solution
Modified the `run_command` function to:
- Safely parse command strings using `shlex.split()`.
- Use `shell=False` in `subprocess.Popen` to prevent shell-based exploitation.
- Ensure compatibility with both string and list inputs for the `command` argument.

---
*PR created automatically by Jules for task [5465781547405743535](https://jules.google.com/task/5465781547405743535) started by @TrueAlpha-spiral*