### PR TITLE
Fix test suite ModuleNotFoundError by updating pytest pythonpath

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
 addopts = -q
-pythonpath = tas_pythonetics/src
+pythonpath = tas_pythonetics/src .
 


### PR DESCRIPTION
Resolves `ModuleNotFoundError` when running `pytest` locally by configuring `pytest.ini`'s `pythonpath` to properly include both `tas_pythonetics/src` and the root directory `.`.

---
*PR created automatically by Jules for task [14845876431789624617](https://jules.google.com/task/14845876431789624617) started by @TrueAlpha-spiral*