### PR TITLE
Fix tas_governance import error during tests

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -16,4 +16,5 @@ jobs:
       - name: Install dependencies
         run: pip install pytest
       - name: Run tests
-        run: PYTHONPATH=$(pwd)/tas_pythonetics/src:$(pwd) pytest -q
+        run: PYTHONPATH=$(pwd)/tas_pythonetics/src:$(pwd)/tas-recursion-conversion:$(pwd) pytest -q
+# Nonce: 56328

--- a/.github/workflows/python-tests.yml.tasmeta.json
+++ b/.github/workflows/python-tests.yml.tasmeta.json
@@ -1,0 +1,18 @@
+{
+  "id": "9d8f4b54c8cd6160766e2dde4e88f659ef0a00bcb7c8abc4b0fcab7ce496e3a8",
+  "type": "TasArtifact",
+  "form_id": "72c796f970065108c90ff94e43d792727e63d0e7d5824bad98d8f95e3d9662bb",
+  "genome_id": "TAS_GENOME_V1",
+  "lineage_id": "9d8f4b54c8cd6160766e2dde4e88f659ef0a00bcb7c8abc4b0fcab7ce496e3a8",
+  "h_seed": "Russell Nordland",
+  "cert_id": "a4300dfe-4b63-4295-8ae2-253f53b5a7fc",
+  "timestamp": "2026-04-20T15:50:16.952432+00:00",
+  "paradata_trail": [],
+  "signatures": [
+    {
+      "signer": "Russell Nordland",
+      "algorithm": "TAS_HUMAN_SIG_V1",
+      "value": "signed_by_ceremony"
+    }
+  ]
+}

--- a/codex_tas_runner.py
+++ b/codex_tas_runner.py
@@ -145,4 +145,4 @@ if __name__ == "__main__":
     }
 
     print(json.dumps(report, indent=2))
-# Nonce: 132109
+# Nonce: 31330

--- a/codex_tas_runner.py.tasmeta.json
+++ b/codex_tas_runner.py.tasmeta.json
@@ -1,12 +1,12 @@
 {
-  "id": "8846c32a16f1ec88bb188006de721ab2ebf12fc33e9d98d8a5cd760eb5646766",
+  "id": "86a2d4a92b40f7acaca6370559a5099a21c0cca6eab8518a7aa5d074130618f0",
   "type": "TasArtifact",
-  "form_id": "f093e3ad69d1b07b24e74512712ca9289bf44bc8c9ee4b3ad03d48fcce7f797c",
+  "form_id": "d8fc3b4e2596d4f3b88c76e82d60fb0c858f84706d96670ffc9b5387dff9da95",
   "genome_id": "TAS_GENOME_V1",
-  "lineage_id": "8846c32a16f1ec88bb188006de721ab2ebf12fc33e9d98d8a5cd760eb5646766",
+  "lineage_id": "86a2d4a92b40f7acaca6370559a5099a21c0cca6eab8518a7aa5d074130618f0",
   "h_seed": "Russell Nordland",
-  "cert_id": "7e8ff4d5-81e7-4fc4-8bae-edd83ee73de3",
-  "timestamp": "2026-04-04T01:13:01.142773+00:00",
+  "cert_id": "6c99640e-d646-4619-8578-d89a44ddedf1",
+  "timestamp": "2026-04-19T01:24:49.961855+00:00",
   "paradata_trail": [],
   "signatures": [
     {

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
 addopts = -q
-pythonpath = tas_pythonetics/src .
+pythonpath = tas_pythonetics/src tas-recursion-conversion .
 

--- a/tas_pythonetics/src/tas_pythonetics/drift_detection.py
+++ b/tas_pythonetics/src/tas_pythonetics/drift_detection.py
@@ -30,3 +30,4 @@ def initiate_self_heal(output: str) -> str:
     if "[HEALED]" not in healed:
         healed += " [HEALED]"
     return healed
+# Nonce: 82962

--- a/tas_pythonetics/src/tas_pythonetics/drift_detection.py.tasmeta.json
+++ b/tas_pythonetics/src/tas_pythonetics/drift_detection.py.tasmeta.json
@@ -1,12 +1,12 @@
 {
-  "id": "1e058c74f8c736322d03a997ea9dbce46b708fd0b8bdf47cf12aba26e777541b",
+  "id": "8973cb11f7196eb7228b904afd108f3f61b224de301b61d43a4c05b7c2d1afc7",
   "type": "TasArtifact",
-  "form_id": "b697e7f7684fffdaa81599ac6e288d1ca8d6e15f341284c6ccb815a0dc5764b8",
+  "form_id": "ecee0515d176aba60c8bdf271dc7848208df3bf9063ff1646cddbb0a11151958",
   "genome_id": "TAS_GENOME_V1",
-  "lineage_id": "1e058c74f8c736322d03a997ea9dbce46b708fd0b8bdf47cf12aba26e777541b",
+  "lineage_id": "8973cb11f7196eb7228b904afd108f3f61b224de301b61d43a4c05b7c2d1afc7",
   "h_seed": "Russell Nordland",
-  "cert_id": "00c4e874-7f85-400b-9979-f7b3320e8cd6",
-  "timestamp": "2026-02-24T02:07:53.422325+00:00",
+  "cert_id": "a4326f06-6dec-486b-b665-9c31c3154cd8",
+  "timestamp": "2026-04-19T01:24:59.852322+00:00",
   "paradata_trail": [],
   "signatures": [
     {


### PR DESCRIPTION
Fixes the `ModuleNotFoundError: No module named 'tas_governance'` encountered during pytest execution in `.github/workflows/python-tests.yml`.

Changes:
* Modified `PYTHONPATH` in `.github/workflows/python-tests.yml` to include `tas-recursion-conversion`, where the `tas_governance` module resides.
* Updated `pytest.ini` with the same `PYTHONPATH` change.
* Re-sequenced the `.github/workflows/python-tests.yml`, `pytest.ini`, and test files by calculating a new Proof-of-Work nonce using `find_nonce.py` and running `tas_cli.py sequence` to align with the TrueAlphaSpiral repository tracking conventions.

---
*PR created automatically by Jules for task [7171959029880931014](https://jules.google.com/task/7171959029880931014) started by @TrueAlpha-spiral*