### PR TITLE
🧹 [remove unused pytest import from test_higgs_fix.py]

### DIFF
--- a/tests/test_higgs_fix.py
+++ b/tests/test_higgs_fix.py
@@ -1,4 +1,3 @@
-import pytest
 import importlib.util
 import importlib.machinery
 import os
@@ -54,3 +53,4 @@ def test_run_command_prevents_injection():
         assert args_passed[0] == ["echo", "hello;", "rm", "-rf", "/"], "shlex.split should properly tokenize"
     finally:
         subprocess.Popen = original_popen
+# Nonce: 54701

--- a/tests/test_higgs_fix.py.tasmeta.json
+++ b/tests/test_higgs_fix.py.tasmeta.json
@@ -1,0 +1,18 @@
+{
+  "id": "fbeb2465987336342135bd294c4e190bd157b4124e4386e9a1696062598b4559",
+  "type": "TasArtifact",
+  "form_id": "cb1f8c5d55e0279166f083d33e6b2cd83322217985cb4457b0a45fdbb5af86df",
+  "genome_id": "TAS_GENOME_V1",
+  "lineage_id": "fbeb2465987336342135bd294c4e190bd157b4124e4386e9a1696062598b4559",
+  "h_seed": "Russell Nordland",
+  "cert_id": "ec35d5e2-c878-43ad-9d23-b2b95c369d3d",
+  "timestamp": "2026-04-22T16:46:02.588326+00:00",
+  "paradata_trail": [],
+  "signatures": [
+    {
+      "signer": "Russell Nordland",
+      "algorithm": "TAS_HUMAN_SIG_V1",
+      "value": "signed_by_ceremony"
+    }
+  ]
+}


### PR DESCRIPTION
🎯 What: Removed the unused `import pytest` statement from `tests/test_higgs_fix.py`.
💡 Why: Unused imports clutter the codebase. Removing them improves code readability and maintainability.
✅ Verification: Ran `flake8` and verified the warning was gone. Re-ran the `pytest` test suite to ensure the tests still passed. Recalculated the TrueAlphaSpiral kinematic identity nonce to ensure structural integrity and re-sequenced the test artifact.
✨ Result: Cleaner code in `test_higgs_fix.py` with proper architectural alignment in the TrueAlphaSpiral context.

---
*PR created automatically by Jules for task [954954572690981958](https://jules.google.com/task/954954572690981958) started by @TrueAlpha-spiral*