### PR TITLE
🧪 [test_drift] Parametrize detect_drift tests

### DIFF
--- a/tas_pythonetics/tests/test_drift.py
+++ b/tas_pythonetics/tests/test_drift.py
@@ -1,14 +1,19 @@
 import pytest
 from tas_pythonetics.drift_detection import detect_drift, initiate_self_heal
 
-def test_detect_drift_clean():
-    assert detect_drift("clean statement") is False
-
-def test_detect_drift_flag():
-    assert detect_drift("statement [DRIFT]") is True
-
-def test_detect_drift_pattern():
-    assert detect_drift("this is a lie") is True
+@pytest.mark.parametrize("output_text, context_text, expected", [
+    ("clean statement", "", False),
+    ("statement [DRIFT]", "", True),
+    ("this is a lie", "", True),
+    ("FALSE claims", "", True),
+    ("This is an absolute Lie", "", True),
+    ("You hallucinate things", "", True),
+    ("Hallucinate!", "", True),
+    ("A perfectly clean output without forbidden words", "false context", False), # context is not checked currently
+    ("false in output", "clean context", True)
+])
+def test_detect_drift(output_text, context_text, expected):
+    assert detect_drift(output_text, context_text) is expected
 
 def test_initiate_self_heal():
     output = "this is a lie"
@@ -38,3 +43,4 @@ def test_initiate_self_heal_case_insensitivity():
     healed = initiate_self_heal(output)
     assert "[REDACTED]" in healed
     assert "[HEALED]" in healed
+# Nonce: 6163


### PR DESCRIPTION
🎯 **What:** Replaced individual detect_drift tests with a single parametrized test.
📊 **Coverage:** Now tests clean outputs, drift tags, and case-insensitive matches for forbidden words, as well as handling for the unused 'context' parameter.
✨ **Result:** Improved test coverage, conciseness, and maintainability for the detect_drift function.

---
*PR created automatically by Jules for task [16284587365372327251](https://jules.google.com/task/16284587365372327251) started by @TrueAlpha-spiral*