### PR TITLE
🧪 [testing improvement] Add tests for EnergyState validation

### DIFF
--- a/tas_pythonetics/tests/test_tasw_hamiltonian.py
+++ b/tas_pythonetics/tests/test_tasw_hamiltonian.py
@@ -1,0 +1,62 @@
+import pytest
+import math
+
+from core.physics.tasw_hamiltonian import EnergyState
+
+def test_energy_state_total_conversion():
+    state1 = EnergyState(total=10)
+    assert isinstance(state1.total, float)
+    assert state1.total == 10.0
+
+    state2 = EnergyState(total="20.5")
+    assert isinstance(state2.total, float)
+    assert state2.total == 20.5
+
+def test_energy_state_one_component_provided():
+    # Only kinetic
+    state1 = EnergyState(total=10.0, kinetic=4.0)
+    assert state1.total == 10.0
+
+    # Only potential
+    state2 = EnergyState(total=10.0, potential=6.0)
+    assert state2.total == 10.0
+
+def test_energy_state_both_components_match():
+    state = EnergyState(total=10.0, kinetic=4.0, potential=6.0)
+    assert state.total == 10.0
+    assert state.kinetic == 4.0
+    assert state.potential == 6.0
+
+def test_energy_state_both_components_match_types():
+    # Provide int strings, etc.
+    state = EnergyState(total="10", kinetic=4, potential="6")
+    assert state.total == 10.0
+
+def test_energy_state_mismatch_raises_value_error():
+    with pytest.raises(ValueError, match=r"EnergyState total must equal kinetic \+ potential when both provided."):
+        EnergyState(total=10.0, kinetic=4.0, potential=5.0)
+
+def test_energy_state_mismatch_within_tolerance():
+    # Should not raise ValueError because difference is within tolerance
+    state = EnergyState(total=10.0, kinetic=4.0, potential=6.0000000001)
+    assert state.total == 10.0
+
+def test_energy_state_mismatch_outside_tolerance():
+    # Should raise ValueError because difference is outside tolerance
+    with pytest.raises(ValueError):
+        EnergyState(total=10.0, kinetic=4.0, potential=6.00000001)
+
+def test_energy_state_nan_total():
+    # total is NaN, so check is bypassed even if components don't match
+    state = EnergyState(total=float('nan'), kinetic=4.0, potential=5.0)
+    assert math.isnan(state.total)
+
+def test_energy_state_inf_total():
+    # total is inf, so check is bypassed
+    state = EnergyState(total=float('inf'), kinetic=4.0, potential=5.0)
+    assert math.isinf(state.total)
+
+def test_energy_state_winding_ignored():
+    state = EnergyState(total=10.0, kinetic=4.0, potential=6.0, winding=99.9)
+    assert state.winding == 99.9
+# Nonce: 5458

--- a/tas_pythonetics/tests/test_tasw_hamiltonian.py.tasmeta.json
+++ b/tas_pythonetics/tests/test_tasw_hamiltonian.py.tasmeta.json
@@ -1,0 +1,18 @@
+{
+  "id": "64cadaccfa1f8e13e4201529317b9415b4f0b0cf09f21be01a8585bfe0ef9780",
+  "type": "TasArtifact",
+  "form_id": "cf8b99c59f87e81e8b820c89102b662dede4da88f8a9f662d047d4ef9e200886",
+  "genome_id": "TAS_GENOME_V1",
+  "lineage_id": "64cadaccfa1f8e13e4201529317b9415b4f0b0cf09f21be01a8585bfe0ef9780",
+  "h_seed": "Russell Nordland",
+  "cert_id": "a596252b-7d73-4691-b2c6-e9fb3802511d",
+  "timestamp": "2026-04-22T16:44:10.999373+00:00",
+  "paradata_trail": [],
+  "signatures": [
+    {
+      "signer": "Russell Nordland",
+      "algorithm": "TAS_HUMAN_SIG_V1",
+      "value": "signed_by_ceremony"
+    }
+  ]
+}


### PR DESCRIPTION
🎯 **What:** Added missing unit tests for the EnergyState.__post_init__ validation logic in core/physics/tasw_hamiltonian.py.
📊 **Coverage:** Tests cover initialization type conversion, matching/mismatched components, boundary behavior (within/outside tolerance), and NaN/Inf edge cases.
✨ **Result:** Improved reliability and code coverage for EnergyState parameter validation.

---
*PR created automatically by Jules for task [14390180826478071458](https://jules.google.com/task/14390180826478071458) started by @TrueAlpha-spiral*