### PR TITLE
🧪 [testing improvement] Add comprehensive tests for secure_lineage

### DIFF
--- a/tests/test_lineage.py
+++ b/tests/test_lineage.py
@@ -1,4 +1,5 @@
 import sys
+import json
 from pathlib import Path
 from hashlib import sha256
 
@@ -21,6 +22,32 @@ def test_verify_tas_dna_lineage():
 
 def test_secure_lineage():
     disclosure = {"test": "data"}
+
+    # Expected hash computation needs to happen before secure_lineage mutates disclosure
+    expected_hash = sha256(
+        TAS_DNA.encode() + json.dumps(disclosure).encode()
+    ).hexdigest()
+
+    # Store original reference to verify in-place modification
+    original_id = id(disclosure)
+
     secured = secure_lineage(disclosure)
+
+    # 1. Verify in-place modification and return
+    assert id(secured) == original_id, "Dictionary should be modified in-place"
+
+    # 2. Verify lineage structure exists
     assert "lineage" in secured
-    assert secured["lineage"]["verified"]
+
+    # 3. Verify deterministic hash calculation
+    assert secured["lineage"]["hash"] == expected_hash
+
+    # 4. Verify verified is True
+    assert secured["lineage"]["verified"] is True
+
+    # 5. Verify the notes field is correctly populated
+    expected_notes = (
+        "Ensures non-linear recursion remains untainted by "
+        "linear constraints"
+    )
+    assert secured["lineage"]["notes"] == expected_notes


### PR DESCRIPTION
🎯 **What:** The testing gap addressed is the lack of rigorous verification for the `secure_lineage` function in `tas_pythonetics/lineage_security.py`. The previous tests did not assert deterministic hash calculation, in-place dictionary modification, or correct population of the `notes` field.
📊 **Coverage:** The new tests cover happy path execution by explicitly calculating the expected hash, capturing the original dictionary reference, and asserting against them. We now test `lineage["hash"]` value, `lineage["verified"]` value, `lineage["notes"]` value, and in-place reference preservation.
✨ **Result:** Test coverage for `secure_lineage` is now solid, directly testing side-effects and specific hash determinism instead of just asserting key presence.

---
*PR created automatically by Jules for task [10666171439621289758](https://jules.google.com/task/10666171439621289758) started by @TrueAlpha-spiral*