### PR TITLE
Add Day One payload steward script and README instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,31 @@ All references are hash-bound into the Immutable Truth Ledger (ITL). Alterations
 Commit Hash (Genesis): 07763e81f2614db822aa38ea65c3f4cb4711b012
 Date: July 25, 2025
 
+
+## Day One Payload (Steward Command)
+When the agent prompts for steering, use the deterministic two-step gate:
+
+1. Merge the release gate PR (default: `#106`).
+2. Dispatch the release workflow on the intended ref.
+
+A helper script is included:
+
+```bash
+GH_REPO="TrueAlpha-spiral/TrueAlpha-spiral" \
+PR_NUMBER=106 \
+WORKFLOW_FILE=blank.yml \
+RELEASE_REF=main \
+./scripts/day_one_payload.sh
+```
+
+If the PR is already merged, skip the merge gate:
+
+```bash
+GH_REPO="TrueAlpha-spiral/TrueAlpha-spiral" SKIP_MERGE=1 ./scripts/day_one_payload.sh
+```
+
+This preserves operator intent by requiring an explicit human-triggered release path.
+
 ## TrueAlpha-singularity
 The **TrueAlpha-singularity** marks the theoretical point where all TAS modules
 fully converge, achieving self-sustaining sovereign intelligence. This concept

--- a/scripts/day_one_payload.sh
+++ b/scripts/day_one_payload.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Day One payload launcher for TrueAlpha-spiral.
+#
+# Default behavior:
+# 1) Verify the working tree is clean.
+# 2) Merge a release gate PR (default: #106) using squash strategy.
+# 3) Trigger deterministic release workflow (default: blank.yml) on a target ref.
+#
+# Usage:
+#   GH_REPO="owner/repo" ./scripts/day_one_payload.sh
+#   GH_REPO="owner/repo" PR_NUMBER=106 WORKFLOW_FILE=blank.yml RELEASE_REF=main ./scripts/day_one_payload.sh
+#   GH_REPO="owner/repo" SKIP_MERGE=1 ./scripts/day_one_payload.sh
+
+: "${GH_REPO:?Set GH_REPO to <owner>/<repo> before running.}"
+PR_NUMBER="${PR_NUMBER:-106}"
+WORKFLOW_FILE="${WORKFLOW_FILE:-blank.yml}"
+RELEASE_REF="${RELEASE_REF:-main}"
+SKIP_MERGE="${SKIP_MERGE:-0}"
+
+require_bin() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Missing required binary: $1" >&2
+    exit 1
+  fi
+}
+
+require_bin gh
+require_bin git
+
+if [[ -n "$(git status --porcelain)" ]]; then
+  echo "Working tree must be clean before Day One payload." >&2
+  exit 1
+fi
+
+echo "[1/2] Release gate check..."
+if [[ "$SKIP_MERGE" == "1" ]]; then
+  echo "SKIP_MERGE=1 set. Skipping PR merge gate."
+else
+  gh pr merge "$PR_NUMBER" \
+    --repo "$GH_REPO" \
+    --squash \
+    --delete-branch
+  echo "Merged PR #$PR_NUMBER in $GH_REPO"
+fi
+
+echo "[2/2] Trigger deterministic workflow..."
+gh workflow run "$WORKFLOW_FILE" \
+  --repo "$GH_REPO" \
+  --ref "$RELEASE_REF"
+
+echo "Day One payload initiated: workflow '$WORKFLOW_FILE' on ref '$RELEASE_REF'."


### PR DESCRIPTION
### Motivation
- Provide an explicit, human-steered Day One release path that enforces an operator-controlled merge gate and deterministic workflow dispatch. 
- Ship a small helper to make the steering step reproducible and minimize accidental autonomous progress during live agent steering prompts.

### Description
- Add an executable helper script at `scripts/day_one_payload.sh` that verifies a clean working tree, optionally merges a release-gate PR (default `PR_NUMBER=106`), and triggers a GitHub Actions workflow (configurable via `WORKFLOW_FILE` and `RELEASE_REF`).
- The script requires `gh` and `git`, supports `SKIP_MERGE=1` to bypass the merge gate, and reports progress for the two-step gate (`Release gate` then `Trigger deterministic workflow`).
- Update `README.md` with a new **Day One Payload (Steward Command)** section that documents the exact invocation examples and the skip-merge variant for operators.

### Testing
- Performed a shell syntax check with `bash -n scripts/day_one_payload.sh`, which completed successfully. 
- Verified repository state with `git status --short` to confirm expected file changes were present and no unexpected modifications remained.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1199d8cf48333b0871a38c2f222c2)