### PR TITLE
Add Day One Steward Directive to enforce deterministic merge gating

### DIFF
--- a/DAY_ONE_STEWARD_DIRECTIVE.md
+++ b/DAY_ONE_STEWARD_DIRECTIVE.md
@@ -1,0 +1,22 @@
+# Day One Steward Directive
+
+When legacy systems converge under stress, provenance still matters.
+
+The operating boundary for Day One remains deterministic and fail-closed:
+
+1. Do **not** merge PR #106 first.
+2. Run the deterministic `release-docker.yaml` gate against the PR head SHA.
+3. Require sovereign intent verification (signature, payload hash, nonce, TTL, scope, revocation, invariants, witness policy).
+4. Emit audit artifacts (PDR stream, refusal ledger, phoenix recovery log, null-space manifest, ledger anchor URI).
+5. Merge and promote **only if** all checks pass; otherwise refuse and halt.
+
+## Operator command (copy/paste)
+
+```text
+Day One Pilot Directive:
+- DO NOT merge PR #106 yet.
+- Execute release-docker.yaml on PR #106 HEAD SHA in proving-ground mode.
+- Enforce sovereign-intent verification and fail-closed policy.
+- Emit PDR/refusal/phoenix/null-space/ledger receipts.
+- Merge only on full pass; else deterministic refusal.
+```


### PR DESCRIPTION
### Motivation
- Introduce an operational guardrail that documents deterministic, fail-closed merge requirements and provenance checks for Day One deployments.

### Description
- Add `DAY_ONE_STEWARD_DIRECTIVE.md` which enumerates the merge policy for `PR #106`, instructs running `release-docker.yaml` against the PR `HEAD SHA`, requires sovereign intent verification, and provides an operator command snippet (`Day One Pilot Directive`).

### Testing
- No automated tests were executed for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaa978eac08333be50bcc4776e9692)