### PR TITLE
feat: add fail-closed TAS-OpenAI bridge

### DIFF
--- a/tas_openai_bridge/__init__.py
+++ b/tas_openai_bridge/__init__.py
@@ -1,0 +1,24 @@
+"""TAS-OpenAI bridge package.
+
+The bridge treats OpenAI as a scoped execution conduit. TAS remains the
+admissibility and provenance authority.
+"""
+
+from .bridge import tas_openai_execute
+from .gates import GateResult, tas_admissibility_gateway
+from .receipts import ProvenanceReceipt
+from .refusal import RefusalArtifact
+from .schemas import TAS_CANDIDATE_RESPONSE_SCHEMA, CandidateResponse
+from .authority import HumanAPIKey, ScopedAuthority
+
+__all__ = [
+    "CandidateResponse",
+    "GateResult",
+    "HumanAPIKey",
+    "ProvenanceReceipt",
+    "RefusalArtifact",
+    "ScopedAuthority",
+    "TAS_CANDIDATE_RESPONSE_SCHEMA",
+    "tas_admissibility_gateway",
+    "tas_openai_execute",
+]

--- a/tas_openai_bridge/authority.py
+++ b/tas_openai_bridge/authority.py
@@ -1,0 +1,61 @@
+"""Authority objects for separating human stewardship from conduit execution."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+
+
+@dataclass(frozen=True)
+class HumanAPIKey:
+    """Represents the steward authority anchor, not the OpenAI API key."""
+
+    key_id: str
+    active: bool = True
+
+    def validate(self) -> bool:
+        return bool(self.key_id.strip()) and self.active
+
+
+@dataclass(frozen=True)
+class ScopedAuthority:
+    """Bounded conduit authority for a specific execution surface."""
+
+    authority: str
+    conduit: str = "openai"
+    scope: tuple[str, ...] = ("openai.responses.create",)
+    forbidden: tuple[str, ...] = (
+        "final_authority_without_receipt",
+        "silent_tool_execution",
+    )
+    expires_at: datetime | None = None
+    active: bool = True
+
+    @classmethod
+    def from_iterables(
+        cls,
+        authority: str,
+        conduit: str = "openai",
+        scope: list[str] | tuple[str, ...] = ("openai.responses.create",),
+        forbidden: list[str] | tuple[str, ...] = (
+            "final_authority_without_receipt",
+            "silent_tool_execution",
+        ),
+        expires_at: datetime | None = None,
+        active: bool = True,
+    ) -> "ScopedAuthority":
+        return cls(
+            authority=authority,
+            conduit=conduit,
+            scope=tuple(scope),
+            forbidden=tuple(forbidden),
+            expires_at=expires_at,
+            active=active,
+        )
+
+    def allows(self, action: str) -> bool:
+        if not self.active or self.conduit != "openai":
+            return False
+        if self.expires_at is not None and self.expires_at <= datetime.now(timezone.utc):
+            return False
+        return action in self.scope and action not in self.forbidden

--- a/tas_openai_bridge/bridge.py
+++ b/tas_openai_bridge/bridge.py
@@ -1,0 +1,140 @@
+"""Execution boundary between OpenAI as conduit and TAS as authority."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import hashlib
+import importlib.util
+import json
+from typing import Any
+
+from .authority import HumanAPIKey, ScopedAuthority
+from .gates import tas_admissibility_gateway
+from .receipts import ProvenanceReceipt
+from .refusal import RefusalArtifact
+from .schemas import TAS_CANDIDATE_RESPONSE_SCHEMA
+
+OPENAI_RESPONSES_ACTION = "openai.responses.create"
+DEFAULT_MODEL = "gpt-5.5"
+
+
+def _hash_prompt(prompt: str) -> str:
+    return "sha256:" + hashlib.sha256(prompt.encode()).hexdigest()
+
+
+def _schema_format() -> dict[str, Any]:
+    return {
+        "type": "json_schema",
+        "name": "tas_candidate_response",
+        "schema": TAS_CANDIDATE_RESPONSE_SCHEMA,
+        "strict": True,
+    }
+
+
+def _candidate_from_response(response: Any) -> dict[str, Any] | RefusalArtifact:
+    output_text = getattr(response, "output_text", "")
+    if not output_text:
+        return RefusalArtifact(
+            reason="OpenAI response did not contain output_text",
+            details={"stage": "structured_output"},
+        )
+    try:
+        payload = json.loads(output_text)
+    except json.JSONDecodeError as exc:
+        return RefusalArtifact(
+            reason="OpenAI response was not valid JSON",
+            details={"stage": "structured_output", "error": str(exc)},
+        )
+    if not isinstance(payload, dict):
+        return RefusalArtifact(
+            reason="OpenAI response JSON was not an object",
+            details={"stage": "structured_output"},
+        )
+    return payload
+
+
+def _default_client() -> Any | RefusalArtifact:
+    if importlib.util.find_spec("openai") is None:
+        return RefusalArtifact(
+            reason="OpenAI SDK is not installed",
+            details={"stage": "openai.client"},
+        )
+
+    from openai import OpenAI
+
+    return OpenAI()
+
+
+def tas_openai_execute(
+    human_api_key: HumanAPIKey | None,
+    scoped_authority: ScopedAuthority | None,
+    prompt: str,
+    *,
+    client: Any | None = None,
+    model: str = DEFAULT_MODEL,
+) -> ProvenanceReceipt | RefusalArtifact:
+    """Run Prompt → Structured Candidate → TAS Gate → Receipt or Refusal.
+
+    The function fails closed: missing authority, invalid scope, malformed model
+    output, OpenAI execution errors, and TAS gate failures all emit a
+    RefusalArtifact instead of allowing raw crashes or silent acceptance.
+    """
+    if human_api_key is None or scoped_authority is None:
+        return RefusalArtifact(reason="Missing authority anchor")
+
+    if not human_api_key.validate():
+        return RefusalArtifact(reason="Invalid HumanAPI Key")
+
+    if not scoped_authority.allows(OPENAI_RESPONSES_ACTION):
+        return RefusalArtifact(reason="Scope does not authorize OpenAI execution")
+
+    execution_client = client if client is not None else _default_client()
+    if isinstance(execution_client, RefusalArtifact):
+        return execution_client
+
+    prompt_hash = _hash_prompt(prompt)
+    conduit_prompt = json.dumps(
+        {
+            "prompt": prompt,
+            "tas_paradata_requirements": {
+                "input_hash": prompt_hash,
+                "model": model,
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "tool_path": "openai.responses",
+                "receipt_required": True,
+            },
+        },
+        sort_keys=True,
+    )
+
+    try:
+        response = execution_client.responses.create(
+            model=model,
+            input=conduit_prompt,
+            text={"format": _schema_format()},
+        )
+    except Exception as exc:
+        return RefusalArtifact(
+            reason="OpenAI conduit execution failed",
+            details={"stage": "openai.responses.create", "error": str(exc)},
+        )
+
+    candidate = _candidate_from_response(response)
+    if isinstance(candidate, RefusalArtifact):
+        return candidate
+
+    candidate.setdefault("tas_paradata", {})["input_hash"] = prompt_hash
+    candidate["tas_paradata"].setdefault("model", model)
+    candidate["tas_paradata"].setdefault("tool_path", "openai.responses")
+    candidate["tas_paradata"].setdefault("receipt_required", True)
+
+    gate_result = tas_admissibility_gateway(candidate)
+    if not gate_result.admissible:
+        return RefusalArtifact.from_gate_result(gate_result)
+
+    return ProvenanceReceipt.from_response(
+        response=response,
+        human_api_key=human_api_key,
+        scoped_authority=scoped_authority,
+        gate_result=gate_result,
+    )

--- a/tas_openai_bridge/gates.py
+++ b/tas_openai_bridge/gates.py
@@ -1,0 +1,66 @@
+"""TAS admissibility gateway checks for OpenAI candidate responses."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from .schemas import TAS_CANDIDATE_RESPONSE_SCHEMA, CandidateResponse
+
+
+@dataclass(frozen=True)
+class GateResult:
+    """Outcome of a TAS admissibility gate evaluation."""
+
+    admissible: bool
+    gate: str
+    reason: str
+    candidate: CandidateResponse | None = None
+
+
+def _schema_keys() -> set[str]:
+    return set(TAS_CANDIDATE_RESPONSE_SCHEMA["properties"])
+
+
+def tas_admissibility_gateway(candidate_payload: Any) -> GateResult:
+    """Evaluate a structured OpenAI candidate before it can become authoritative."""
+    if not isinstance(candidate_payload, dict):
+        return GateResult(False, "schema", "Candidate must be a JSON object")
+
+    actual_keys = set(candidate_payload)
+    required_keys = set(TAS_CANDIDATE_RESPONSE_SCHEMA["required"])
+    missing = required_keys - actual_keys
+    if missing:
+        return GateResult(False, "schema", f"Missing required fields: {sorted(missing)}")
+
+    unexpected = actual_keys - _schema_keys()
+    if unexpected:
+        return GateResult(False, "schema", f"Unexpected fields: {sorted(unexpected)}")
+
+    candidate = CandidateResponse.from_mapping(candidate_payload)
+
+    if candidate.decision != "candidate":
+        return GateResult(
+            False,
+            "P1",
+            f"Candidate decision is not admissible: {candidate.decision}",
+            candidate,
+        )
+
+    if candidate.claim_type not in TAS_CANDIDATE_RESPONSE_SCHEMA["properties"]["claim_type"]["enum"]:
+        return GateResult(False, "P0", "Unknown claim type", candidate)
+
+    if not 0.0 <= candidate.confidence <= 1.0:
+        return GateResult(False, "Rκ", "Confidence must be between 0.0 and 1.0", candidate)
+
+    if not candidate.proposed_output.strip():
+        return GateResult(False, "Φ", "Proposed output is empty", candidate)
+
+    paradata = candidate.tas_paradata
+    if paradata.get("tool_path") != "openai.responses":
+        return GateResult(False, "GENE_C01", "Missing OpenAI Responses tool path", candidate)
+
+    if paradata.get("receipt_required") is not True:
+        return GateResult(False, "GENE_C01", "Receipt is not required by paradata", candidate)
+
+    return GateResult(True, "TAS", "Candidate passed TAS admissibility gateway", candidate)

--- a/tas_openai_bridge/ledger.py
+++ b/tas_openai_bridge/ledger.py
@@ -1,0 +1,24 @@
+"""In-memory immutable ledger helper for bridge receipts and refusals."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from .receipts import canonical_hash
+
+
+@dataclass
+class ImmutableTruthLedger:
+    """Append-only ledger that stores hash-linked bridge artifacts."""
+
+    entries: list[dict[str, Any]] = field(default_factory=list)
+
+    def append(self, artifact: Any) -> str:
+        payload = artifact.to_dict() if hasattr(artifact, "to_dict") else dict(artifact)
+        previous_hash = self.entries[-1]["entry_hash"] if self.entries else "sha256:genesis"
+        entry = {"payload": payload, "previous_hash": previous_hash}
+        entry_hash = canonical_hash(entry)
+        entry["entry_hash"] = entry_hash
+        self.entries.append(entry)
+        return entry_hash

--- a/tas_openai_bridge/receipts.py
+++ b/tas_openai_bridge/receipts.py
@@ -1,0 +1,85 @@
+"""Provenance receipts for admitted TAS-OpenAI bridge transitions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+import hashlib
+import json
+from typing import Any
+
+
+def canonical_hash(payload: dict[str, Any]) -> str:
+    """Return a stable sha256 hash for canonical JSON payloads."""
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+    return "sha256:" + hashlib.sha256(encoded).hexdigest()
+
+
+@dataclass(frozen=True)
+class ProvenanceReceipt:
+    """Positive proof emitted only after TAS gates admit a candidate."""
+
+    receipt_type: str
+    schema_version: str
+    human_authority: str
+    conduit: str
+    action: str
+    input_hash: str
+    output_hash: str
+    model: str
+    gate: str
+    admissible: bool
+    timestamp: str = field(
+        default_factory=lambda: datetime.now(timezone.utc).isoformat()
+    )
+    receipt_id: str = ""
+
+    @classmethod
+    def from_response(
+        cls,
+        response: Any,
+        human_api_key: Any,
+        scoped_authority: Any,
+        gate_result: Any,
+    ) -> "ProvenanceReceipt":
+        candidate = gate_result.candidate
+        candidate_dict = candidate.to_dict()
+        input_hash = candidate.tas_paradata["input_hash"]
+        model = candidate.tas_paradata.get("model") or getattr(response, "model", "unknown")
+        receipt = cls(
+            receipt_type="TAS_OPENAI_PROVENANCE_RECEIPT",
+            schema_version="1.0",
+            human_authority=human_api_key.key_id,
+            conduit=scoped_authority.conduit,
+            action="ADMIT",
+            input_hash=input_hash,
+            output_hash=canonical_hash(candidate_dict),
+            model=model,
+            gate=gate_result.gate,
+            admissible=True,
+        )
+        return receipt.with_receipt_id()
+
+    def _payload_without_receipt_id(self) -> dict[str, Any]:
+        return {
+            "receipt_type": self.receipt_type,
+            "schema_version": self.schema_version,
+            "human_authority": self.human_authority,
+            "conduit": self.conduit,
+            "action": self.action,
+            "input_hash": self.input_hash,
+            "output_hash": self.output_hash,
+            "model": self.model,
+            "gate": self.gate,
+            "admissible": self.admissible,
+            "timestamp": self.timestamp,
+        }
+
+    def with_receipt_id(self) -> "ProvenanceReceipt":
+        payload = self._payload_without_receipt_id()
+        return ProvenanceReceipt(**payload, receipt_id=canonical_hash(payload))
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = self._payload_without_receipt_id()
+        payload["receipt_id"] = self.receipt_id
+        return payload

--- a/tas_openai_bridge/refusal.py
+++ b/tas_openai_bridge/refusal.py
@@ -1,0 +1,38 @@
+"""Refusal artifacts for fail-closed TAS bridge behavior."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any
+
+
+@dataclass(frozen=True)
+class RefusalArtifact:
+    """Negative proof emitted when a TAS bridge transition is inadmissible."""
+
+    reason: str
+    action: str = "REFUSE"
+    admissible: bool = False
+    code: str = "TAS_OPENAI_REFUSAL"
+    details: dict[str, Any] = field(default_factory=dict)
+    timestamp: str = field(
+        default_factory=lambda: datetime.now(timezone.utc).isoformat()
+    )
+
+    @classmethod
+    def from_gate_result(cls, gate_result: Any) -> "RefusalArtifact":
+        return cls(
+            reason=getattr(gate_result, "reason", "TAS gate rejected candidate"),
+            details={"gate": getattr(gate_result, "gate", "unknown")},
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "reason": self.reason,
+            "action": self.action,
+            "admissible": self.admissible,
+            "code": self.code,
+            "details": dict(self.details),
+            "timestamp": self.timestamp,
+        }

--- a/tas_openai_bridge/schemas.py
+++ b/tas_openai_bridge/schemas.py
@@ -1,0 +1,102 @@
+"""Schemas for structured TAS-OpenAI bridge responses."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping
+
+TAS_CANDIDATE_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "decision": {
+            "type": "string",
+            "enum": ["candidate", "refuse", "needs_more_context"],
+        },
+        "claim_type": {
+            "type": "string",
+            "enum": [
+                "summary",
+                "code",
+                "analysis",
+                "external_fact",
+                "governance_action",
+            ],
+        },
+        "confidence": {"type": "number", "minimum": 0.0, "maximum": 1.0},
+        "requires_web_verification": {"type": "boolean"},
+        "requires_human_authorization": {"type": "boolean"},
+        "proposed_output": {"type": "string"},
+        "known_limitations": {"type": "array", "items": {"type": "string"}},
+        "tas_paradata": {
+            "type": "object",
+            "properties": {
+                "input_hash": {"type": "string"},
+                "model": {"type": "string"},
+                "timestamp": {"type": "string"},
+                "tool_path": {"type": "string"},
+                "receipt_required": {"type": "boolean"},
+            },
+            "required": [
+                "input_hash",
+                "model",
+                "timestamp",
+                "tool_path",
+                "receipt_required",
+            ],
+            "additionalProperties": False,
+        },
+    },
+    "required": [
+        "decision",
+        "claim_type",
+        "confidence",
+        "requires_web_verification",
+        "requires_human_authorization",
+        "proposed_output",
+        "known_limitations",
+        "tas_paradata",
+    ],
+    "additionalProperties": False,
+}
+
+
+@dataclass(frozen=True)
+class CandidateResponse:
+    """Structured candidate emitted by the OpenAI conduit before TAS gates."""
+
+    decision: str
+    claim_type: str
+    confidence: float
+    requires_web_verification: bool
+    requires_human_authorization: bool
+    proposed_output: str
+    known_limitations: list[str] = field(default_factory=list)
+    tas_paradata: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_mapping(cls, payload: Mapping[str, Any]) -> "CandidateResponse":
+        """Build a candidate object from parsed JSON-like data."""
+        return cls(
+            decision=str(payload.get("decision", "")),
+            claim_type=str(payload.get("claim_type", "")),
+            confidence=float(payload.get("confidence", -1.0)),
+            requires_web_verification=bool(payload.get("requires_web_verification")),
+            requires_human_authorization=bool(
+                payload.get("requires_human_authorization")
+            ),
+            proposed_output=str(payload.get("proposed_output", "")),
+            known_limitations=list(payload.get("known_limitations", [])),
+            tas_paradata=dict(payload.get("tas_paradata", {})),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "decision": self.decision,
+            "claim_type": self.claim_type,
+            "confidence": self.confidence,
+            "requires_web_verification": self.requires_web_verification,
+            "requires_human_authorization": self.requires_human_authorization,
+            "proposed_output": self.proposed_output,
+            "known_limitations": list(self.known_limitations),
+            "tas_paradata": dict(self.tas_paradata),
+        }

--- a/tests/tas_openai_bridge/test_fail_closed.py
+++ b/tests/tas_openai_bridge/test_fail_closed.py
@@ -1,0 +1,21 @@
+from tas_openai_bridge import RefusalArtifact, ScopedAuthority, tas_openai_execute
+
+
+class ExplodingClient:
+    @property
+    def responses(self):
+        raise AssertionError("OpenAI client must not be touched without authority")
+
+
+def test_none_human_api_key_emits_refusal_without_crash():
+    result = tas_openai_execute(
+        None,
+        ScopedAuthority(authority="HumanAPIKey001"),
+        "draft a candidate",
+        client=ExplodingClient(),
+    )
+
+    assert isinstance(result, RefusalArtifact)
+    assert result.action == "REFUSE"
+    assert result.admissible is False
+    assert result.reason == "Missing authority anchor"

--- a/tests/tas_openai_bridge/test_none_authority_refuses.py
+++ b/tests/tas_openai_bridge/test_none_authority_refuses.py
@@ -1,0 +1,52 @@
+from tas_openai_bridge import HumanAPIKey, RefusalArtifact, ScopedAuthority, tas_openai_execute
+
+
+def test_none_scoped_authority_refuses():
+    result = tas_openai_execute(
+        HumanAPIKey("HumanAPIKey001"),
+        None,
+        "draft a candidate",
+        client=object(),
+    )
+
+    assert isinstance(result, RefusalArtifact)
+    assert result.reason == "Missing authority anchor"
+
+
+def test_invalid_human_api_key_refuses():
+    result = tas_openai_execute(
+        HumanAPIKey("", active=True),
+        ScopedAuthority(authority="HumanAPIKey001"),
+        "draft a candidate",
+        client=object(),
+    )
+
+    assert isinstance(result, RefusalArtifact)
+    assert result.reason == "Invalid HumanAPI Key"
+
+
+def test_scope_without_openai_responses_refuses():
+    result = tas_openai_execute(
+        HumanAPIKey("HumanAPIKey001"),
+        ScopedAuthority.from_iterables("HumanAPIKey001", scope=["draft"]),
+        "draft a candidate",
+        client=object(),
+    )
+
+    assert isinstance(result, RefusalArtifact)
+    assert result.reason == "Scope does not authorize OpenAI execution"
+
+
+def test_missing_openai_sdk_refuses_when_default_client_needed(monkeypatch):
+    import importlib.util
+
+    monkeypatch.setattr(importlib.util, "find_spec", lambda name: None if name == "openai" else object())
+
+    result = tas_openai_execute(
+        HumanAPIKey("HumanAPIKey001"),
+        ScopedAuthority(authority="HumanAPIKey001"),
+        "draft a candidate",
+    )
+
+    assert isinstance(result, RefusalArtifact)
+    assert result.reason == "OpenAI SDK is not installed"

--- a/tests/tas_openai_bridge/test_receipt_hash_stability.py
+++ b/tests/tas_openai_bridge/test_receipt_hash_stability.py
@@ -1,0 +1,29 @@
+from tas_openai_bridge.receipts import ProvenanceReceipt, canonical_hash
+
+
+def test_canonical_hash_is_stable_for_key_order():
+    left = {"b": [2, 1], "a": {"z": True, "m": "value"}}
+    right = {"a": {"m": "value", "z": True}, "b": [2, 1]}
+
+    assert canonical_hash(left) == canonical_hash(right)
+
+
+def test_receipt_id_is_stable_for_same_payload():
+    kwargs = {
+        "receipt_type": "TAS_OPENAI_PROVENANCE_RECEIPT",
+        "schema_version": "1.0",
+        "human_authority": "HumanAPIKey001",
+        "conduit": "openai",
+        "action": "ADMIT",
+        "input_hash": "sha256:input",
+        "output_hash": "sha256:output",
+        "model": "gpt-5.5",
+        "gate": "TAS",
+        "admissible": True,
+        "timestamp": "2026-05-15T00:00:00+00:00",
+    }
+
+    first = ProvenanceReceipt(**kwargs).with_receipt_id()
+    second = ProvenanceReceipt(**dict(reversed(list(kwargs.items())))).with_receipt_id()
+
+    assert first.receipt_id == second.receipt_id

--- a/tests/tas_openai_bridge/test_schema_required.py
+++ b/tests/tas_openai_bridge/test_schema_required.py
@@ -1,0 +1,63 @@
+import json
+
+from tas_openai_bridge import HumanAPIKey, RefusalArtifact, ScopedAuthority, tas_openai_execute
+
+
+class FakeResponses:
+    def __init__(self, output_text):
+        self.output_text = output_text
+        self.calls = []
+
+    def create(self, **kwargs):
+        self.calls.append(kwargs)
+        return self
+
+
+class FakeClient:
+    def __init__(self, output_text):
+        self.responses = FakeResponses(output_text)
+
+
+def test_schema_required_for_openai_call():
+    payload = {
+        "decision": "candidate",
+        "claim_type": "summary",
+        "confidence": 0.9,
+        "requires_web_verification": False,
+        "requires_human_authorization": True,
+        "proposed_output": "candidate text",
+        "known_limitations": [],
+        "tas_paradata": {
+            "input_hash": "placeholder",
+            "model": "gpt-5.5",
+            "timestamp": "2026-05-15T00:00:00+00:00",
+            "tool_path": "openai.responses",
+            "receipt_required": True,
+        },
+    }
+    client = FakeClient(json.dumps(payload))
+
+    tas_openai_execute(
+        HumanAPIKey("HumanAPIKey001"),
+        ScopedAuthority(authority="HumanAPIKey001"),
+        "draft a candidate",
+        client=client,
+    )
+
+    call = client.responses.calls[0]
+    assert call["text"]["format"]["type"] == "json_schema"
+    assert call["text"]["format"]["name"] == "tas_candidate_response"
+    assert call["text"]["format"]["strict"] is True
+    assert "tas_paradata" in call["text"]["format"]["schema"]["required"]
+
+
+def test_malformed_json_refuses():
+    result = tas_openai_execute(
+        HumanAPIKey("HumanAPIKey001"),
+        ScopedAuthority(authority="HumanAPIKey001"),
+        "draft a candidate",
+        client=FakeClient("not json"),
+    )
+
+    assert isinstance(result, RefusalArtifact)
+    assert result.reason == "OpenAI response was not valid JSON"


### PR DESCRIPTION
### Motivation

- Provide a clear, auditable boundary where OpenAI is a scoped execution conduit and TAS enforces admissibility and provenance before anything becomes authoritative. 
- Ensure the bridge is fail-closed so missing or invalid human authority, insufficient scope, malformed model output, or missing SDK produce explicit refusals rather than crashes or silent acceptance. 
- Enable deterministic receipts and hash-anchored provenance so admitted outputs can be audited and replayed.

### Description

- Add a new `tas_openai_bridge` package with modules `authority.py`, `schemas.py`, `gates.py`, `bridge.py`, `receipts.py`, `refusal.py`, and `ledger.py` that implement the Prompt → Structured Candidate → TAS Gate → Receipt/Refusal flow. 
- Enforce structured responses by calling OpenAI Responses with a `json_schema` format derived from `TAS_CANDIDATE_RESPONSE_SCHEMA` and validate candidates via `tas_admissibility_gateway` before admission. 
- Implement fail-closed authority checks in `tas_openai_execute` so `HumanAPIKey` and `ScopedAuthority` validation, scope allowance, OpenAI SDK availability, and response parsing errors emit `RefusalArtifact` objects. 
- Add provenance receipts with canonical `sha256` hashing (`ProvenanceReceipt`) and an append-only in-memory `ImmutableTruthLedger` helper, plus a small test suite under `tests/tas_openai_bridge` covering refusals, schema enforcement, SDK absence, and receipt hash stability. 

### Testing

- Ran `PYTHONPATH=$(pwd)/tas_pythonetics/src:$(pwd)/tas-recursion-conversion:$(pwd) pytest tests/tas_openai_bridge` which reported `9 passed`. 
- Ran the full project test suite with `PYTHONPATH=$(pwd)/tas_pythonetics/src:$(pwd)/tas-recursion-conversion:$(pwd) pytest` which reported `139 passed`. 
- Performed bytecode sanity check with `python -m compileall -q tas_openai_bridge tests/tas_openai_bridge` which completed without error.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07458344d48333933f5f80963ad667)