### PR TITLE
fix: harden TAS OpenAI bridge fail-closed review path

### DIFF
--- a/tas_openai_bridge/bridge.py
+++ b/tas_openai_bridge/bridge.py
@@ -32,7 +32,7 @@ def _schema_format() -> dict[str, Any]:
     }
 
 
-def _message_content_from_response(response: Any) -> str:
+def _message_content_from_response(response: Any) -> Any:
     output_text = getattr(response, "output_text", "")
     if output_text:
         return output_text
@@ -53,9 +53,17 @@ def _candidate_from_response(response: Any) -> dict[str, Any] | RefusalArtifact:
             reason="OpenAI response did not contain candidate content",
             details={"stage": "structured_output"},
         )
+    if not isinstance(output_text, str):
+        return RefusalArtifact(
+            reason="OpenAI response candidate content was not a string",
+            details={
+                "stage": "structured_output",
+                "content_type": type(output_text).__name__,
+            },
+        )
     try:
         payload = json.loads(output_text)
-    except json.JSONDecodeError as exc:
+    except (json.JSONDecodeError, TypeError) as exc:
         return RefusalArtifact(
             reason="OpenAI response was not valid JSON",
             details={"stage": "structured_output", "error": str(exc)},

--- a/tas_openai_bridge/bridge.py
+++ b/tas_openai_bridge/bridge.py
@@ -15,7 +15,8 @@ from .refusal import RefusalArtifact
 from .schemas import TAS_CANDIDATE_RESPONSE_SCHEMA
 
 OPENAI_RESPONSES_ACTION = "openai.responses.create"
-DEFAULT_MODEL = "gpt-5.5"
+OPENAI_CHAT_COMPLETIONS_STAGE = "openai.chat.completions.create"
+DEFAULT_MODEL = "gpt-4o"
 
 
 def _hash_prompt(prompt: str) -> str:
@@ -31,11 +32,25 @@ def _schema_format() -> dict[str, Any]:
     }
 
 
-def _candidate_from_response(response: Any) -> dict[str, Any] | RefusalArtifact:
+def _message_content_from_response(response: Any) -> str:
     output_text = getattr(response, "output_text", "")
+    if output_text:
+        return output_text
+
+    choices = getattr(response, "choices", None)
+    if not choices:
+        return ""
+
+    message = getattr(choices[0], "message", None)
+    content = getattr(message, "content", "") if message is not None else ""
+    return content or ""
+
+
+def _candidate_from_response(response: Any) -> dict[str, Any] | RefusalArtifact:
+    output_text = _message_content_from_response(response)
     if not output_text:
         return RefusalArtifact(
-            reason="OpenAI response did not contain output_text",
+            reason="OpenAI response did not contain candidate content",
             details={"stage": "structured_output"},
         )
     try:
@@ -60,9 +75,39 @@ def _default_client() -> Any | RefusalArtifact:
             details={"stage": "openai.client"},
         )
 
-    from openai import OpenAI
+    try:
+        from openai import OpenAI
 
-    return OpenAI()
+        return OpenAI()
+    except Exception as exc:
+        return RefusalArtifact(
+            reason="OpenAI client initialization failed",
+            details={"stage": "openai.client", "error": str(exc)},
+        )
+
+
+def _ensure_candidate_paradata(
+    candidate: dict[str, Any],
+    *,
+    prompt_hash: str,
+    model: str,
+) -> RefusalArtifact | None:
+    paradata = candidate.get("tas_paradata")
+    if paradata is None:
+        paradata = {}
+        candidate["tas_paradata"] = paradata
+    elif not isinstance(paradata, dict):
+        return RefusalArtifact(
+            reason="tas_paradata must be an object",
+            details={"stage": "candidate.paradata"},
+        )
+
+    paradata["input_hash"] = prompt_hash
+    paradata.setdefault("timestamp", datetime.now(timezone.utc).isoformat())
+    paradata.setdefault("model", model)
+    paradata.setdefault("tool_path", "openai.responses")
+    paradata.setdefault("receipt_required", True)
+    return None
 
 
 def tas_openai_execute(
@@ -108,25 +153,28 @@ def tas_openai_execute(
     )
 
     try:
-        response = execution_client.responses.create(
+        response = execution_client.chat.completions.create(
             model=model,
-            input=conduit_prompt,
-            text={"format": _schema_format()},
+            messages=[{"role": "user", "content": conduit_prompt}],
+            response_format=_schema_format(),
         )
     except Exception as exc:
         return RefusalArtifact(
             reason="OpenAI conduit execution failed",
-            details={"stage": "openai.responses.create", "error": str(exc)},
+            details={"stage": OPENAI_CHAT_COMPLETIONS_STAGE, "error": str(exc)},
         )
 
     candidate = _candidate_from_response(response)
     if isinstance(candidate, RefusalArtifact):
         return candidate
 
-    candidate.setdefault("tas_paradata", {})["input_hash"] = prompt_hash
-    candidate["tas_paradata"].setdefault("model", model)
-    candidate["tas_paradata"].setdefault("tool_path", "openai.responses")
-    candidate["tas_paradata"].setdefault("receipt_required", True)
+    paradata_refusal = _ensure_candidate_paradata(
+        candidate,
+        prompt_hash=prompt_hash,
+        model=model,
+    )
+    if paradata_refusal is not None:
+        return paradata_refusal
 
     gate_result = tas_admissibility_gateway(candidate)
     if not gate_result.admissible:

--- a/tas_openai_bridge/gates.py
+++ b/tas_openai_bridge/gates.py
@@ -37,7 +37,25 @@ def tas_admissibility_gateway(candidate_payload: Any) -> GateResult:
     if unexpected:
         return GateResult(False, "schema", f"Unexpected fields: {sorted(unexpected)}")
 
-    candidate = CandidateResponse.from_mapping(candidate_payload)
+    paradata = candidate_payload.get("tas_paradata", {})
+    if not isinstance(paradata, dict):
+        return GateResult(False, "schema", "tas_paradata must be an object")
+
+    paradata_required = set(
+        TAS_CANDIDATE_RESPONSE_SCHEMA["properties"]["tas_paradata"]["required"]
+    )
+    missing_paradata = paradata_required - set(paradata)
+    if missing_paradata:
+        return GateResult(
+            False,
+            "schema",
+            f"Missing required paradata fields: {sorted(missing_paradata)}",
+        )
+
+    try:
+        candidate = CandidateResponse.from_mapping(candidate_payload)
+    except (TypeError, ValueError) as exc:
+        return GateResult(False, "schema", f"Candidate coercion failed: {exc}")
 
     if candidate.decision != "candidate":
         return GateResult(
@@ -56,7 +74,6 @@ def tas_admissibility_gateway(candidate_payload: Any) -> GateResult:
     if not candidate.proposed_output.strip():
         return GateResult(False, "Φ", "Proposed output is empty", candidate)
 
-    paradata = candidate.tas_paradata
     if paradata.get("tool_path") != "openai.responses":
         return GateResult(False, "GENE_C01", "Missing OpenAI Responses tool path", candidate)
 

--- a/tas_openai_bridge/ledger.py
+++ b/tas_openai_bridge/ledger.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from threading import Lock
 from typing import Any
 
 from .receipts import canonical_hash
@@ -13,12 +14,14 @@ class ImmutableTruthLedger:
     """Append-only ledger that stores hash-linked bridge artifacts."""
 
     entries: list[dict[str, Any]] = field(default_factory=list)
+    _lock: Lock = field(default_factory=Lock, init=False, repr=False)
 
     def append(self, artifact: Any) -> str:
         payload = artifact.to_dict() if hasattr(artifact, "to_dict") else dict(artifact)
-        previous_hash = self.entries[-1]["entry_hash"] if self.entries else "sha256:genesis"
-        entry = {"payload": payload, "previous_hash": previous_hash}
-        entry_hash = canonical_hash(entry)
-        entry["entry_hash"] = entry_hash
-        self.entries.append(entry)
-        return entry_hash
+        with self._lock:
+            previous_hash = self.entries[-1]["entry_hash"] if self.entries else "sha256:genesis"
+            entry = {"payload": payload, "previous_hash": previous_hash}
+            entry_hash = canonical_hash(entry)
+            entry["entry_hash"] = entry_hash
+            self.entries.append(entry)
+            return entry_hash

--- a/tas_openai_bridge/schemas.py
+++ b/tas_openai_bridge/schemas.py
@@ -73,20 +73,45 @@ class CandidateResponse:
     known_limitations: list[str] = field(default_factory=list)
     tas_paradata: dict[str, Any] = field(default_factory=dict)
 
+    @staticmethod
+    def _coerce_confidence(value: Any) -> float:
+        try:
+            return float(value)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("confidence must be numeric") from exc
+
+    @staticmethod
+    def _coerce_known_limitations(value: Any) -> list[str]:
+        if not isinstance(value, list):
+            raise ValueError("known_limitations must be a list")
+        return [str(item) for item in value]
+
+    @staticmethod
+    def _coerce_paradata(value: Any) -> dict[str, Any]:
+        if not isinstance(value, dict):
+            raise ValueError("tas_paradata must be an object")
+        return dict(value)
+
     @classmethod
     def from_mapping(cls, payload: Mapping[str, Any]) -> "CandidateResponse":
-        """Build a candidate object from parsed JSON-like data."""
+        """Build a candidate object from parsed JSON-like data.
+
+        Malformed conduit output raises ValueError so the TAS gateway can reject
+        the candidate cleanly instead of allowing parsing exceptions to escape.
+        """
         return cls(
             decision=str(payload.get("decision", "")),
             claim_type=str(payload.get("claim_type", "")),
-            confidence=float(payload.get("confidence", -1.0)),
+            confidence=cls._coerce_confidence(payload.get("confidence", -1.0)),
             requires_web_verification=bool(payload.get("requires_web_verification")),
             requires_human_authorization=bool(
                 payload.get("requires_human_authorization")
             ),
             proposed_output=str(payload.get("proposed_output", "")),
-            known_limitations=list(payload.get("known_limitations", [])),
-            tas_paradata=dict(payload.get("tas_paradata", {})),
+            known_limitations=cls._coerce_known_limitations(
+                payload.get("known_limitations", [])
+            ),
+            tas_paradata=cls._coerce_paradata(payload.get("tas_paradata", {})),
         )
 
     def to_dict(self) -> dict[str, Any]:

--- a/tests/tas_openai_bridge/test_schema_required.py
+++ b/tests/tas_openai_bridge/test_schema_required.py
@@ -74,6 +74,19 @@ def test_malformed_json_refuses():
     assert result.reason == "OpenAI response was not valid JSON"
 
 
+def test_non_string_candidate_content_refuses():
+    result = tas_openai_execute(
+        HumanAPIKey("HumanAPIKey001"),
+        ScopedAuthority(authority="HumanAPIKey001"),
+        "draft a candidate",
+        client=FakeClient([{"type": "text", "text": "not a JSON string"}]),
+    )
+
+    assert isinstance(result, RefusalArtifact)
+    assert result.reason == "OpenAI response candidate content was not a string"
+    assert result.details["content_type"] == "list"
+
+
 def test_non_object_tas_paradata_refuses_before_mutation():
     result = tas_openai_execute(
         HumanAPIKey("HumanAPIKey001"),

--- a/tests/tas_openai_bridge/test_schema_required.py
+++ b/tests/tas_openai_bridge/test_schema_required.py
@@ -1,24 +1,28 @@
 import json
+from types import SimpleNamespace
 
 from tas_openai_bridge import HumanAPIKey, RefusalArtifact, ScopedAuthority, tas_openai_execute
+from tas_openai_bridge.gates import tas_admissibility_gateway
 
 
-class FakeResponses:
+class FakeChatCompletions:
     def __init__(self, output_text):
         self.output_text = output_text
         self.calls = []
 
     def create(self, **kwargs):
         self.calls.append(kwargs)
-        return self
+        return SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content=self.output_text))]
+        )
 
 
 class FakeClient:
     def __init__(self, output_text):
-        self.responses = FakeResponses(output_text)
+        self.chat = SimpleNamespace(completions=FakeChatCompletions(output_text))
 
 
-def test_schema_required_for_openai_call():
+def candidate_payload(**overrides):
     payload = {
         "decision": "candidate",
         "claim_type": "summary",
@@ -29,13 +33,18 @@ def test_schema_required_for_openai_call():
         "known_limitations": [],
         "tas_paradata": {
             "input_hash": "placeholder",
-            "model": "gpt-5.5",
+            "model": "gpt-4o",
             "timestamp": "2026-05-15T00:00:00+00:00",
             "tool_path": "openai.responses",
             "receipt_required": True,
         },
     }
-    client = FakeClient(json.dumps(payload))
+    payload.update(overrides)
+    return payload
+
+
+def test_schema_required_for_openai_call():
+    client = FakeClient(json.dumps(candidate_payload()))
 
     tas_openai_execute(
         HumanAPIKey("HumanAPIKey001"),
@@ -44,11 +53,13 @@ def test_schema_required_for_openai_call():
         client=client,
     )
 
-    call = client.responses.calls[0]
-    assert call["text"]["format"]["type"] == "json_schema"
-    assert call["text"]["format"]["name"] == "tas_candidate_response"
-    assert call["text"]["format"]["strict"] is True
-    assert "tas_paradata" in call["text"]["format"]["schema"]["required"]
+    call = client.chat.completions.calls[0]
+    assert call["model"] == "gpt-4o"
+    assert call["messages"][0]["role"] == "user"
+    assert call["response_format"]["type"] == "json_schema"
+    assert call["response_format"]["name"] == "tas_candidate_response"
+    assert call["response_format"]["strict"] is True
+    assert "tas_paradata" in call["response_format"]["schema"]["required"]
 
 
 def test_malformed_json_refuses():
@@ -61,3 +72,35 @@ def test_malformed_json_refuses():
 
     assert isinstance(result, RefusalArtifact)
     assert result.reason == "OpenAI response was not valid JSON"
+
+
+def test_non_object_tas_paradata_refuses_before_mutation():
+    result = tas_openai_execute(
+        HumanAPIKey("HumanAPIKey001"),
+        ScopedAuthority(authority="HumanAPIKey001"),
+        "draft a candidate",
+        client=FakeClient(json.dumps(candidate_payload(tas_paradata="not an object"))),
+    )
+
+    assert isinstance(result, RefusalArtifact)
+    assert result.reason == "tas_paradata must be an object"
+
+
+def test_gateway_rejects_missing_nested_paradata_fields():
+    payload = candidate_payload(tas_paradata={"input_hash": "sha256:abc"})
+
+    result = tas_admissibility_gateway(payload)
+
+    assert result.admissible is False
+    assert result.gate == "schema"
+    assert "Missing required paradata fields" in result.reason
+
+
+def test_gateway_rejects_invalid_confidence_without_crashing():
+    payload = candidate_payload(confidence="oops")
+
+    result = tas_admissibility_gateway(payload)
+
+    assert result.admissible is False
+    assert result.gate == "schema"
+    assert "confidence must be numeric" in result.reason


### PR DESCRIPTION
## What

Applies the required review-bridge corrections for the TAS OpenAI bridge fail-closed boundary.

## Why

The review feedback identified compatibility and refusal-path risks in PR #164. The bridge must treat OpenAI as a conduit and TAS as the authority, which means malformed conduit setup, malformed model output, missing paradata, SDK mismatch, and concurrent ledger writes must fail closed instead of raw-crashing or silently passing.

## Changes

- Align bridge execution with the reviewed Chat Completions structured-output path:
  - `client.chat.completions.create(...)`
  - `messages=[{"role": "user", "content": conduit_prompt}]`
  - `response_format=_schema_format()`
- Replace `output_text`-only extraction with `choices[0].message.content` support while keeping fallback compatibility.
- Replace invalid default model identifier with `gpt-4o`.
- Guard default OpenAI client construction and return `RefusalArtifact` on SDK/init failures.
- Validate `tas_paradata` before mutation and refuse non-object paradata cleanly.
- Inject required paradata timestamp when missing.
- Enforce nested `tas_paradata` required fields in the TAS gate.
- Catch malformed `confidence` coercion and convert it to a `GateResult` refusal.
- Add a lock around `ImmutableTruthLedger.append(...)` to preserve hash-chain consistency under concurrent writes.
- Update and expand tests for:
  - reviewed SDK call shape
  - malformed JSON refusal
  - non-object paradata refusal
  - missing nested paradata fields
  - invalid confidence refusal without crash

## Invariant

No conduit output becomes authoritative unless schema, paradata, scope, and receipt requirements pass the TAS gate. Bad setup or bad model output must emit refusal, not runtime escape.