### PR TITLE
🔒 [security fix] Implement AlgorithmicPolymath and harden runtime refusal consistency gate

### DIFF
--- a/pr_description.txt
+++ b/pr_description.txt
@@ -1,6 +1,9 @@
-Title: 🧪 [testing improvement] Add missing tests for EnergyState.__post_init__ validation
+Title: 🔒 [security fix] Implement AlgorithmicPolymath and harden runtime refusal consistency gate
 
 Description:
-🎯 **What:** The `EnergyState` class in `tasw_hamiltonian.py` had an untested `__post_init__` method that handles total float conversion, missing component tolerance, and kinetic/potential sum validation.
-📊 **Coverage:** A new suite of unit tests has been added to `tas_pythonetics/tests/core/physics/test_tasw_hamiltonian.py` covering: float conversion for totals, valid sums passing, valid sums with floating-point tolerance passing, invalid sums raising `ValueError`, total fields set to `NaN`/`Inf` skipping checks, and cases where 1 or 0 components are provided skipping sum validation checks.
-✨ **Result:** The `EnergyState.__post_init__` validation logic now has 100% test coverage, significantly reducing the risk of regressions in TAS-W Hamiltonian state generation.
+🎯 **What:** Implemented `AlgorithmicPolymath`, the runtime constraint coordinator, and audited the bridge layer (`bridge.py`), admissibility gateway (`gates.py`), and ledger/receipt paths.
+🛡️ **Risk:** Previously, if a raw exception occurred during conduit execution or admissibility evaluation, the execution could crash raw or escape the boundaries of the `RefusalArtifact` requirement. A broken or non-existent lineage or authority could bypass some runtime rules if handled improperly by the calling context.
+🔧 **Solution:**
+- Created `AlgorithmicPolymath` which explicitly binds the execution to a human API key, scoped authority, lineage anchor, and a ledger, failing closed and emitting a `RefusalArtifact` on any missing or invalid state.
+- Wrapped the execution code inside `tas_openai_execute` and `tas_admissibility_gateway` in broad `try...except` blocks to catch unexpected errors and return `RefusalArtifact` or failed `GateResult` objects.
+- Added must-fail tests proving that missing authority, malformed scope, missing lineage, malformed conduit output, and ledger append failures correctly emit a `RefusalArtifact` without crashing.

--- a/tas_openai_bridge/__init__.py
+++ b/tas_openai_bridge/__init__.py
@@ -4,6 +4,7 @@ The bridge treats OpenAI as a scoped execution conduit. TAS remains the
 admissibility and provenance authority.
 """
 
+from .polymath import AlgorithmicPolymath
 from .bridge import tas_openai_execute
 from .gates import GateResult, tas_admissibility_gateway
 from .receipts import ProvenanceReceipt
@@ -12,6 +13,7 @@ from .schemas import TAS_CANDIDATE_RESPONSE_SCHEMA, CandidateResponse
 from .authority import HumanAPIKey, ScopedAuthority
 
 __all__ = [
+    "AlgorithmicPolymath",
     "CandidateResponse",
     "GateResult",
     "HumanAPIKey",

--- a/tas_openai_bridge/bridge.py
+++ b/tas_openai_bridge/bridge.py
@@ -79,62 +79,68 @@ def tas_openai_execute(
     output, OpenAI execution errors, and TAS gate failures all emit a
     RefusalArtifact instead of allowing raw crashes or silent acceptance.
     """
-    if human_api_key is None or scoped_authority is None:
-        return RefusalArtifact(reason="Missing authority anchor")
-
-    if not human_api_key.validate():
-        return RefusalArtifact(reason="Invalid HumanAPI Key")
-
-    if not scoped_authority.allows(OPENAI_RESPONSES_ACTION):
-        return RefusalArtifact(reason="Scope does not authorize OpenAI execution")
-
-    execution_client = client if client is not None else _default_client()
-    if isinstance(execution_client, RefusalArtifact):
-        return execution_client
-
-    prompt_hash = _hash_prompt(prompt)
-    conduit_prompt = json.dumps(
-        {
-            "prompt": prompt,
-            "tas_paradata_requirements": {
-                "input_hash": prompt_hash,
-                "model": model,
-                "timestamp": datetime.now(timezone.utc).isoformat(),
-                "tool_path": "openai.responses",
-                "receipt_required": True,
-            },
-        },
-        sort_keys=True,
-    )
-
     try:
-        response = execution_client.responses.create(
-            model=model,
-            input=conduit_prompt,
-            text={"format": _schema_format()},
+        if human_api_key is None or scoped_authority is None:
+            return RefusalArtifact(reason="Missing authority anchor")
+
+        if not human_api_key.validate():
+            return RefusalArtifact(reason="Invalid HumanAPI Key")
+
+        if not scoped_authority.allows(OPENAI_RESPONSES_ACTION):
+            return RefusalArtifact(reason="Scope does not authorize OpenAI execution")
+
+        execution_client = client if client is not None else _default_client()
+        if isinstance(execution_client, RefusalArtifact):
+            return execution_client
+
+        prompt_hash = _hash_prompt(prompt)
+        conduit_prompt = json.dumps(
+            {
+                "prompt": prompt,
+                "tas_paradata_requirements": {
+                    "input_hash": prompt_hash,
+                    "model": model,
+                    "timestamp": datetime.now(timezone.utc).isoformat(),
+                    "tool_path": "openai.responses",
+                    "receipt_required": True,
+                },
+            },
+            sort_keys=True,
+        )
+
+        try:
+            response = execution_client.responses.create(
+                model=model,
+                input=conduit_prompt,
+                text={"format": _schema_format()},
+            )
+        except Exception as exc:
+            return RefusalArtifact(
+                reason="OpenAI conduit execution failed",
+                details={"stage": "openai.responses.create", "error": str(exc)},
+            )
+
+        candidate = _candidate_from_response(response)
+        if isinstance(candidate, RefusalArtifact):
+            return candidate
+
+        candidate.setdefault("tas_paradata", {})["input_hash"] = prompt_hash
+        candidate["tas_paradata"].setdefault("model", model)
+        candidate["tas_paradata"].setdefault("tool_path", "openai.responses")
+        candidate["tas_paradata"].setdefault("receipt_required", True)
+
+        gate_result = tas_admissibility_gateway(candidate)
+        if not gate_result.admissible:
+            return RefusalArtifact.from_gate_result(gate_result)
+
+        return ProvenanceReceipt.from_response(
+            response=response,
+            human_api_key=human_api_key,
+            scoped_authority=scoped_authority,
+            gate_result=gate_result,
         )
     except Exception as exc:
         return RefusalArtifact(
-            reason="OpenAI conduit execution failed",
-            details={"stage": "openai.responses.create", "error": str(exc)},
+            reason="Unhandled runtime exception in TAS bridge",
+            details={"error": str(exc)},
         )
-
-    candidate = _candidate_from_response(response)
-    if isinstance(candidate, RefusalArtifact):
-        return candidate
-
-    candidate.setdefault("tas_paradata", {})["input_hash"] = prompt_hash
-    candidate["tas_paradata"].setdefault("model", model)
-    candidate["tas_paradata"].setdefault("tool_path", "openai.responses")
-    candidate["tas_paradata"].setdefault("receipt_required", True)
-
-    gate_result = tas_admissibility_gateway(candidate)
-    if not gate_result.admissible:
-        return RefusalArtifact.from_gate_result(gate_result)
-
-    return ProvenanceReceipt.from_response(
-        response=response,
-        human_api_key=human_api_key,
-        scoped_authority=scoped_authority,
-        gate_result=gate_result,
-    )

--- a/tas_openai_bridge/gates.py
+++ b/tas_openai_bridge/gates.py
@@ -24,43 +24,65 @@ def _schema_keys() -> set[str]:
 
 def tas_admissibility_gateway(candidate_payload: Any) -> GateResult:
     """Evaluate a structured OpenAI candidate before it can become authoritative."""
-    if not isinstance(candidate_payload, dict):
-        return GateResult(False, "schema", "Candidate must be a JSON object")
+    try:
+        if not isinstance(candidate_payload, dict):
+            return GateResult(False, "schema", "Candidate must be a JSON object")
 
-    actual_keys = set(candidate_payload)
-    required_keys = set(TAS_CANDIDATE_RESPONSE_SCHEMA["required"])
-    missing = required_keys - actual_keys
-    if missing:
-        return GateResult(False, "schema", f"Missing required fields: {sorted(missing)}")
+        actual_keys = set(candidate_payload)
+        required_keys = set(TAS_CANDIDATE_RESPONSE_SCHEMA["required"])
+        missing = required_keys - actual_keys
+        if missing:
+            return GateResult(
+                False, "schema", f"Missing required fields: {sorted(missing)}"
+            )
 
-    unexpected = actual_keys - _schema_keys()
-    if unexpected:
-        return GateResult(False, "schema", f"Unexpected fields: {sorted(unexpected)}")
+        unexpected = actual_keys - _schema_keys()
+        if unexpected:
+            return GateResult(
+                False, "schema", f"Unexpected fields: {sorted(unexpected)}"
+            )
 
-    candidate = CandidateResponse.from_mapping(candidate_payload)
+        candidate = CandidateResponse.from_mapping(candidate_payload)
 
-    if candidate.decision != "candidate":
+        if candidate.decision != "candidate":
+            return GateResult(
+                False,
+                "P1",
+                f"Candidate decision is not admissible: {candidate.decision}",
+                candidate,
+            )
+
+        if (
+            candidate.claim_type
+            not in TAS_CANDIDATE_RESPONSE_SCHEMA["properties"]["claim_type"]["enum"]
+        ):
+            return GateResult(False, "P0", "Unknown claim type", candidate)
+
+        if not 0.0 <= candidate.confidence <= 1.0:
+            return GateResult(
+                False, "Rκ", "Confidence must be between 0.0 and 1.0", candidate
+            )
+
+        if not candidate.proposed_output.strip():
+            return GateResult(False, "Φ", "Proposed output is empty", candidate)
+
+        paradata = candidate.tas_paradata
+        if paradata.get("tool_path") != "openai.responses":
+            return GateResult(
+                False, "GENE_C01", "Missing OpenAI Responses tool path", candidate
+            )
+
+        if paradata.get("receipt_required") is not True:
+            return GateResult(
+                False, "GENE_C01", "Receipt is not required by paradata", candidate
+            )
+
+        return GateResult(
+            True, "TAS", "Candidate passed TAS admissibility gateway", candidate
+        )
+    except Exception as exc:
         return GateResult(
             False,
-            "P1",
-            f"Candidate decision is not admissible: {candidate.decision}",
-            candidate,
+            "EXCEPTION",
+            f"Unhandled exception in admissibility gateway: {str(exc)}",
         )
-
-    if candidate.claim_type not in TAS_CANDIDATE_RESPONSE_SCHEMA["properties"]["claim_type"]["enum"]:
-        return GateResult(False, "P0", "Unknown claim type", candidate)
-
-    if not 0.0 <= candidate.confidence <= 1.0:
-        return GateResult(False, "Rκ", "Confidence must be between 0.0 and 1.0", candidate)
-
-    if not candidate.proposed_output.strip():
-        return GateResult(False, "Φ", "Proposed output is empty", candidate)
-
-    paradata = candidate.tas_paradata
-    if paradata.get("tool_path") != "openai.responses":
-        return GateResult(False, "GENE_C01", "Missing OpenAI Responses tool path", candidate)
-
-    if paradata.get("receipt_required") is not True:
-        return GateResult(False, "GENE_C01", "Receipt is not required by paradata", candidate)
-
-    return GateResult(True, "TAS", "Candidate passed TAS admissibility gateway", candidate)

--- a/tas_openai_bridge/polymath.py
+++ b/tas_openai_bridge/polymath.py
@@ -1,0 +1,70 @@
+"""Algorithmic Polymath for coordinated runtime constraints."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .authority import HumanAPIKey, ScopedAuthority
+from .bridge import tas_openai_execute
+from .ledger import ImmutableTruthLedger
+from .receipts import ProvenanceReceipt
+from .refusal import RefusalArtifact
+
+
+class AlgorithmicPolymath:
+    """Coordinates runtime execution under strict authority, lineage, and ledger constraints.
+
+    The Polymath ensures that human intent becomes bounded machine authority through
+    trace-bearing, refusal-capable computation. It catches all runtime exceptions
+    to emit a RefusalArtifact instead of crashing.
+    """
+
+    def __init__(
+        self,
+        human_api_key: HumanAPIKey | None,
+        scoped_authority: ScopedAuthority | None,
+        lineage_anchor: str | None,
+        ledger: ImmutableTruthLedger,
+    ):
+        self.human_api_key = human_api_key
+        self.scoped_authority = scoped_authority
+        self.lineage_anchor = lineage_anchor
+        self.ledger = ledger
+
+    def execute(
+        self, prompt: str, *, client: Any | None = None, model: str = "gpt-5.5"
+    ) -> ProvenanceReceipt | RefusalArtifact:
+        """Execute a prompt through the TAS-OpenAI bridge, failing closed on any error."""
+        try:
+            if not self.human_api_key or not self.human_api_key.validate():
+                return RefusalArtifact(reason="Missing or invalid HumanAPI Key")
+
+            if not self.scoped_authority or not self.scoped_authority.active:
+                return RefusalArtifact(reason="Missing or inactive scoped authority")
+
+            if not self.lineage_anchor or not self.lineage_anchor.strip():
+                return RefusalArtifact(reason="Missing lineage anchor")
+
+            result = tas_openai_execute(
+                human_api_key=self.human_api_key,
+                scoped_authority=self.scoped_authority,
+                prompt=prompt,
+                client=client,
+                model=model,
+            )
+
+            try:
+                self.ledger.append(result)
+            except Exception as exc:
+                return RefusalArtifact(
+                    reason="Receipt-path failure",
+                    details={"stage": "ledger.append", "error": str(exc)},
+                )
+
+            return result
+
+        except Exception as exc:
+            return RefusalArtifact(
+                reason="Unhandled runtime exception escaped into Polymath",
+                details={"error": str(exc)},
+            )

--- a/tests/tas_openai_bridge/test_polymath.py
+++ b/tests/tas_openai_bridge/test_polymath.py
@@ -1,0 +1,133 @@
+import json
+
+from tas_openai_bridge import (
+    AlgorithmicPolymath,
+    HumanAPIKey,
+    RefusalArtifact,
+    ScopedAuthority,
+)
+from tas_openai_bridge.ledger import ImmutableTruthLedger
+
+
+class ExplodingClient:
+    @property
+    def responses(self):
+        raise AssertionError("OpenAI client must not be touched")
+
+
+class BadDataClient:
+    @property
+    def responses(self):
+        class _Responses:
+            def create(self, **kwargs):
+                class _Response:
+                    @property
+                    def output_text(self):
+                        return "{"  # Invalid JSON
+
+                return _Response()
+
+        return _Responses()
+
+
+class GoodClient:
+    @property
+    def responses(self):
+        class _Responses:
+            def create(self, **kwargs):
+                class _Response:
+                    model = "gpt-5.5"
+
+                    @property
+                    def output_text(self):
+                        return json.dumps(
+                            {
+                                "decision": "candidate",
+                                "claim_type": "summary",
+                                "confidence": 0.9,
+                                "requires_web_verification": False,
+                                "requires_human_authorization": True,
+                                "proposed_output": "candidate text",
+                                "known_limitations": [],
+                                "tas_paradata": {
+                                    "input_hash": "placeholder",
+                                    "model": "gpt-5.5",
+                                    "timestamp": "2026-05-15T00:00:00+00:00",
+                                    "tool_path": "openai.responses",
+                                    "receipt_required": True,
+                                },
+                            }
+                        )
+
+                return _Response()
+
+        return _Responses()
+
+
+class ExplodingLedger(ImmutableTruthLedger):
+    def append(self, artifact):
+        raise RuntimeError("Ledger offline")
+
+
+def test_missing_authority_refuses():
+    polymath = AlgorithmicPolymath(
+        human_api_key=None,
+        scoped_authority=ScopedAuthority("HumanAPIKey001"),
+        lineage_anchor="valid_anchor",
+        ledger=ImmutableTruthLedger(),
+    )
+    result = polymath.execute("prompt", client=ExplodingClient())
+    assert isinstance(result, RefusalArtifact)
+    assert "Missing or invalid HumanAPI Key" in result.reason
+
+
+def test_malformed_scope_refuses():
+    polymath = AlgorithmicPolymath(
+        human_api_key=HumanAPIKey("HumanAPIKey001"),
+        scoped_authority=ScopedAuthority.from_iterables(
+            "HumanAPIKey001", scope=["draft"]
+        ),
+        lineage_anchor="valid_anchor",
+        ledger=ImmutableTruthLedger(),
+    )
+    # The polymath delegates to tas_openai_execute, which checks scope and returns RefusalArtifact
+    result = polymath.execute("prompt", client=ExplodingClient())
+    assert isinstance(result, RefusalArtifact)
+    assert "Scope does not authorize OpenAI execution" in result.reason
+
+
+def test_missing_lineage_refuses():
+    polymath = AlgorithmicPolymath(
+        human_api_key=HumanAPIKey("HumanAPIKey001"),
+        scoped_authority=ScopedAuthority("HumanAPIKey001"),
+        lineage_anchor="",
+        ledger=ImmutableTruthLedger(),
+    )
+    result = polymath.execute("prompt", client=ExplodingClient())
+    assert isinstance(result, RefusalArtifact)
+    assert "Missing lineage anchor" in result.reason
+
+
+def test_malformed_conduit_output_refuses():
+    polymath = AlgorithmicPolymath(
+        human_api_key=HumanAPIKey("HumanAPIKey001"),
+        scoped_authority=ScopedAuthority("HumanAPIKey001"),
+        lineage_anchor="valid_anchor",
+        ledger=ImmutableTruthLedger(),
+    )
+    result = polymath.execute("prompt", client=BadDataClient())
+    assert isinstance(result, RefusalArtifact)
+    assert "OpenAI response was not valid JSON" in result.reason
+
+
+def test_receipt_path_failure_refuses():
+    polymath = AlgorithmicPolymath(
+        human_api_key=HumanAPIKey("HumanAPIKey001"),
+        scoped_authority=ScopedAuthority("HumanAPIKey001"),
+        lineage_anchor="valid_anchor",
+        ledger=ExplodingLedger(),
+    )
+    result = polymath.execute("prompt", client=GoodClient())
+    assert isinstance(result, RefusalArtifact)
+    assert "Receipt-path failure" in result.reason
+    assert "Ledger offline" in result.details["error"]


### PR DESCRIPTION
🎯 **What:** Implemented `AlgorithmicPolymath`, the runtime constraint coordinator, and audited the bridge layer (`bridge.py`), admissibility gateway (`gates.py`), and ledger/receipt paths.
🛡️ **Risk:** Previously, if a raw exception occurred during conduit execution or admissibility evaluation, the execution could crash raw or escape the boundaries of the `RefusalArtifact` requirement. A broken or non-existent lineage or authority could bypass some runtime rules if handled improperly by the calling context.
🔧 **Solution:** 
- Created `AlgorithmicPolymath` which explicitly binds the execution to a human API key, scoped authority, lineage anchor, and a ledger, failing closed and emitting a `RefusalArtifact` on any missing or invalid state.
- Wrapped the execution code inside `tas_openai_execute` and `tas_admissibility_gateway` in broad `try...except` blocks to catch unexpected errors and return `RefusalArtifact` or failed `GateResult` objects.
- Added must-fail tests proving that missing authority, malformed scope, missing lineage, malformed conduit output, and ledger append failures correctly emit a `RefusalArtifact` without crashing.

---
*PR created automatically by Jules for task [15525083258922691955](https://jules.google.com/task/15525083258922691955) started by @TrueAlpha-spiral*