### PR TITLE
🔒 [security fix] Sequence tas_openai_bridge modules with Kinematic Identity

### DIFF
--- a/tas_openai_bridge/bridge.py
+++ b/tas_openai_bridge/bridge.py
@@ -144,3 +144,4 @@ def tas_openai_execute(
             reason="Unhandled runtime exception in TAS bridge",
             details={"error": str(exc)},
         )
+# Nonce: 14663

--- a/tas_openai_bridge/bridge.py.tasmeta.json
+++ b/tas_openai_bridge/bridge.py.tasmeta.json
@@ -1,0 +1,18 @@
+{
+  "id": "81d2db8f7f2c128ad026f6ac4e6874ccd7dbf3624be7fadeb3c9cae7741cf8c9",
+  "type": "TasArtifact",
+  "form_id": "8a3bc3bb33a5f2e7df09f1f113eb1bea80a5e03365462a0b377417d2cfdeeb7b",
+  "genome_id": "TAS_GENOME_V1",
+  "lineage_id": "81d2db8f7f2c128ad026f6ac4e6874ccd7dbf3624be7fadeb3c9cae7741cf8c9",
+  "h_seed": "Russell Nordland",
+  "cert_id": "19b7d239-2c03-4052-8948-0d6d2be9af76",
+  "timestamp": "2026-05-17T01:07:27.446907+00:00",
+  "paradata_trail": [],
+  "signatures": [
+    {
+      "signer": "Russell Nordland",
+      "algorithm": "TAS_HUMAN_SIG_V1",
+      "value": "signed_by_ceremony"
+    }
+  ]
+}

--- a/tas_openai_bridge/gates.py
+++ b/tas_openai_bridge/gates.py
@@ -86,3 +86,4 @@ def tas_admissibility_gateway(candidate_payload: Any) -> GateResult:
             "EXCEPTION",
             f"Unhandled exception in admissibility gateway: {str(exc)}",
         )
+# Nonce: 55956

--- a/tas_openai_bridge/gates.py.tasmeta.json
+++ b/tas_openai_bridge/gates.py.tasmeta.json
@@ -1,0 +1,18 @@
+{
+  "id": "d99867965fbdbdf8eefe199973c27e2bc193d8fbf0c5d70f9d33dab45d252ca6",
+  "type": "TasArtifact",
+  "form_id": "83ed1d6e6d0187e859710f0d221fcc73565df19372702bb8eea00d619a736f31",
+  "genome_id": "TAS_GENOME_V1",
+  "lineage_id": "d99867965fbdbdf8eefe199973c27e2bc193d8fbf0c5d70f9d33dab45d252ca6",
+  "h_seed": "Russell Nordland",
+  "cert_id": "0c65cfd1-9f1f-4237-8b25-abec45bf5982",
+  "timestamp": "2026-05-17T01:06:09.743294+00:00",
+  "paradata_trail": [],
+  "signatures": [
+    {
+      "signer": "Russell Nordland",
+      "algorithm": "TAS_HUMAN_SIG_V1",
+      "value": "signed_by_ceremony"
+    }
+  ]
+}

--- a/tas_openai_bridge/polymath.py
+++ b/tas_openai_bridge/polymath.py
@@ -68,3 +68,4 @@ class AlgorithmicPolymath:
                 reason="Unhandled runtime exception escaped into Polymath",
                 details={"error": str(exc)},
             )
+# Nonce: 140535

--- a/tas_openai_bridge/polymath.py.tasmeta.json
+++ b/tas_openai_bridge/polymath.py.tasmeta.json
@@ -1,0 +1,18 @@
+{
+  "id": "975eefbd8e8e1db0a3d0fc8d95a162e2510942cf41138ae930d675792f7559f7",
+  "type": "TasArtifact",
+  "form_id": "a8e04cc70c483888a184e7aee523ebef737fab082b2b4cfafe629e06be8e01c6",
+  "genome_id": "TAS_GENOME_V1",
+  "lineage_id": "975eefbd8e8e1db0a3d0fc8d95a162e2510942cf41138ae930d675792f7559f7",
+  "h_seed": "Russell Nordland",
+  "cert_id": "cd0af18e-9b60-4d95-afe8-9aead667bb02",
+  "timestamp": "2026-05-17T01:03:38.315220+00:00",
+  "paradata_trail": [],
+  "signatures": [
+    {
+      "signer": "Russell Nordland",
+      "algorithm": "TAS_HUMAN_SIG_V1",
+      "value": "signed_by_ceremony"
+    }
+  ]
+}


### PR DESCRIPTION
Add Kinematic Identity (Prime Invariant) metadata tracking for the `tas_openai_bridge` package to comply with the TrueAlphaSpiral framework's requirements for sequencer verification and ledger refusal execution paths.

---
*PR created automatically by Jules for task [8181601314837859217](https://jules.google.com/task/8181601314837859217) started by @TrueAlpha-spiral*