### PR TITLE
Add TAS-OpenAI bridge with structured-output gating, receipts, and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 __pycache__/
 .pytest_cache/
+.env
+.env.*
+!.env.example

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
 addopts = -q
-pythonpath = tas_pythonetics/src
+pythonpath = . tas_pythonetics/src
 

--- a/tas_1st_principles.yaml
+++ b/tas_1st_principles.yaml
@@ -69,6 +69,26 @@ TAS_1st_Principles:
       - Derivatives must reference TAS_HUMAN_SIG lineage
       - Non-consensual mimicry forbidden
 
+  TAS_Primitives:
+    - id: PI_I_001
+      name: Perspective Intelligence Operator
+      symbol: "π_i"
+      class: Irrational Observability Operator
+      doctrine: "Truth is perspective-bound without being perspective-determined."
+      enforcement:
+        - No perspective without provenance
+        - No provenance without authority
+        - No authority without receipt
+      stabilizer: "Φ"
+      failure_modes:
+        - Observer averaged to zero
+        - Unbounded subjectivism
+        - Recursive Dissociation Event
+        - Provenance collapse
+      admissibility_output:
+        - Admission Receipt
+        - Deterministic Refusal
+
   Citation_Protocol:
     function: cite_()
     description: >

--- a/tas_openai_bridge/__init__.py
+++ b/tas_openai_bridge/__init__.py
@@ -3,6 +3,17 @@
 from .bridge import DEFAULT_MODEL, OPENAI_RESPONSES_CREATE, tas_openai_execute
 from .gates import GateResult, tas_admissibility_gateway
 from .ledger import InMemoryLedger
+from .perspective import (
+    PHI,
+    GateStatus,
+    LedgerAuthority,
+    PerspectiveContext,
+    PerspectiveGateResult,
+    PerspectiveOperator,
+    PerspectiveProvenanceReceipt,
+    validate_perspective_context,
+    validate_perspective_operator,
+)
 from .receipts import ProvenanceReceipt, stable_hash
 from .refusal import RefusalArtifact
 from .schemas import TAS_CANDIDATE_RESPONSE_SCHEMA, response_text_format
@@ -11,7 +22,14 @@ __all__ = [
     "DEFAULT_MODEL",
     "OPENAI_RESPONSES_CREATE",
     "GateResult",
+    "GateStatus",
     "InMemoryLedger",
+    "LedgerAuthority",
+    "PHI",
+    "PerspectiveContext",
+    "PerspectiveGateResult",
+    "PerspectiveOperator",
+    "PerspectiveProvenanceReceipt",
     "ProvenanceReceipt",
     "RefusalArtifact",
     "TAS_CANDIDATE_RESPONSE_SCHEMA",
@@ -19,4 +37,6 @@ __all__ = [
     "stable_hash",
     "tas_admissibility_gateway",
     "tas_openai_execute",
+    "validate_perspective_context",
+    "validate_perspective_operator",
 ]

--- a/tas_openai_bridge/__init__.py
+++ b/tas_openai_bridge/__init__.py
@@ -1,0 +1,22 @@
+"""TAS-OpenAI bridge: Prompt -> Structured Candidate -> TAS Gate -> Receipt/Refusal."""
+
+from .bridge import DEFAULT_MODEL, OPENAI_RESPONSES_CREATE, tas_openai_execute
+from .gates import GateResult, tas_admissibility_gateway
+from .ledger import InMemoryLedger
+from .receipts import ProvenanceReceipt, stable_hash
+from .refusal import RefusalArtifact
+from .schemas import TAS_CANDIDATE_RESPONSE_SCHEMA, response_text_format
+
+__all__ = [
+    "DEFAULT_MODEL",
+    "OPENAI_RESPONSES_CREATE",
+    "GateResult",
+    "InMemoryLedger",
+    "ProvenanceReceipt",
+    "RefusalArtifact",
+    "TAS_CANDIDATE_RESPONSE_SCHEMA",
+    "response_text_format",
+    "stable_hash",
+    "tas_admissibility_gateway",
+    "tas_openai_execute",
+]

--- a/tas_openai_bridge/bridge.py
+++ b/tas_openai_bridge/bridge.py
@@ -1,0 +1,112 @@
+"""TAS-OpenAI bridge execution wrapper.
+
+OpenAI is treated as a computational conduit. This module makes TAS authority,
+structured output, and receipt/refusal emission mandatory around that conduit.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .gates import tas_admissibility_gateway
+from .receipts import ProvenanceReceipt
+from .refusal import RefusalArtifact
+from .schemas import response_text_format
+
+OPENAI_RESPONSES_CREATE = "openai.responses.create"
+DEFAULT_MODEL = "gpt-5.5"
+
+
+def _valid_human_api_key(human_api_key: Any) -> bool:
+    if human_api_key is None or not hasattr(human_api_key, "validate"):
+        return False
+    try:
+        return bool(human_api_key.validate())
+    except (AttributeError, TypeError, ValueError):
+        return False
+
+
+def _allows_openai_execution(scoped_authority: Any) -> bool:
+    if scoped_authority is None or not hasattr(scoped_authority, "allows"):
+        return False
+    try:
+        return bool(scoped_authority.allows(OPENAI_RESPONSES_CREATE))
+    except (AttributeError, TypeError, ValueError):
+        return False
+
+
+def _response_output_text(response: Any) -> str | None:
+    try:
+        output_text = getattr(response, "output_text")
+    except (AttributeError, TypeError):
+        return None
+    return output_text if isinstance(output_text, str) else None
+
+
+def tas_openai_execute(
+    human_api_key: Any,
+    scoped_authority: Any,
+    prompt: str,
+    *,
+    client: Any,
+    model: str = DEFAULT_MODEL,
+    ledger: Any | None = None,
+) -> RefusalArtifact | ProvenanceReceipt:
+    """Execute a prompt through OpenAI and return a receipt or refusal.
+
+    All authority validation is fail-closed. Missing, malformed, or exception-
+    raising authority anchors become RefusalArtifact instances rather than raw
+    crashes.
+    """
+
+    if human_api_key is None:
+        return RefusalArtifact(reason="Missing HumanAPI Key", details={"anchor": "human_api_key"})
+
+    if scoped_authority is None:
+        return RefusalArtifact(reason="Missing scoped authority", details={"anchor": "scoped_authority"})
+
+    if not _valid_human_api_key(human_api_key):
+        return RefusalArtifact(reason="Invalid HumanAPI Key", details={"anchor": "human_api_key"})
+
+    if not _allows_openai_execution(scoped_authority):
+        return RefusalArtifact(
+            reason="Scope does not authorize OpenAI execution",
+            details={"operation": OPENAI_RESPONSES_CREATE},
+        )
+
+    if client is None or not hasattr(client, "responses"):
+        return RefusalArtifact(reason="Missing OpenAI Responses client")
+
+    try:
+        response = client.responses.create(
+            model=model,
+            input=prompt,
+            text={"format": response_text_format()},
+        )
+    except (AttributeError, TypeError, ValueError) as exc:
+        return RefusalArtifact(
+            reason="OpenAI conduit failed before structured response",
+            details={"exception_type": type(exc).__name__},
+        )
+
+    candidate = _response_output_text(response)
+    if candidate is None:
+        return RefusalArtifact(reason="OpenAI response missing structured output_text")
+
+    gate_result = tas_admissibility_gateway(candidate)
+    if not gate_result.admissible:
+        refusal = RefusalArtifact.from_gate_result(gate_result)
+        if ledger is not None:
+            ledger.append(refusal)
+        return refusal
+
+    receipt = ProvenanceReceipt.from_response(
+        response=response,
+        human_api_key=human_api_key,
+        scoped_authority=scoped_authority,
+        gate_result=gate_result,
+        candidate=candidate,
+    )
+    if ledger is not None:
+        ledger.append(receipt)
+    return receipt

--- a/tas_openai_bridge/bridge.py
+++ b/tas_openai_bridge/bridge.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from typing import Any
 
 from .gates import tas_admissibility_gateway
+from .perspective import validate_perspective_context
 from .receipts import ProvenanceReceipt
 from .refusal import RefusalArtifact
 from .schemas import response_text_format
@@ -51,6 +52,7 @@ def tas_openai_execute(
     client: Any,
     model: str = DEFAULT_MODEL,
     ledger: Any | None = None,
+    perspective_context: Any | None = None,
 ) -> RefusalArtifact | ProvenanceReceipt:
     """Execute a prompt through OpenAI and return a receipt or refusal.
 
@@ -72,6 +74,22 @@ def tas_openai_execute(
         return RefusalArtifact(
             reason="Scope does not authorize OpenAI execution",
             details={"operation": OPENAI_RESPONSES_CREATE},
+        )
+
+    if perspective_context is None:
+        return RefusalArtifact(
+            reason="Unwitnessed Intent Void",
+            details={"gate": "Perspective Intelligence"},
+        )
+
+    perspective_result = validate_perspective_context(perspective_context)
+    if not perspective_result.admissible:
+        return RefusalArtifact(
+            reason=perspective_result.reason,
+            details={
+                "gate": "Perspective Intelligence",
+                "pi_i_ratio": perspective_result.pi_i_ratio,
+            },
         )
 
     if client is None or not hasattr(client, "responses"):

--- a/tas_openai_bridge/gates.py
+++ b/tas_openai_bridge/gates.py
@@ -1,0 +1,47 @@
+"""Boring deterministic admissibility gates for TAS bridge candidates."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class GateResult:
+    admissible: bool
+    reason: str = "Candidate passed TAS admissibility gateway"
+    gate: str = "TAS_ADMISSIBILITY_GATEWAY"
+
+
+def parse_candidate(candidate: Any) -> dict[str, Any] | None:
+    """Parse a structured candidate from dict or JSON text without raising."""
+
+    if isinstance(candidate, dict):
+        return candidate
+    if isinstance(candidate, str):
+        try:
+            parsed = json.loads(candidate)
+        except (TypeError, json.JSONDecodeError):
+            return None
+        return parsed if isinstance(parsed, dict) else None
+    return None
+
+
+def tas_admissibility_gateway(candidate: Any) -> GateResult:
+    """Decide whether a model candidate can become receipt-bearing output."""
+
+    parsed = parse_candidate(candidate)
+    if parsed is None:
+        return GateResult(False, "Candidate is not structured JSON")
+
+    if parsed.get("decision") != "candidate":
+        return GateResult(False, "Candidate decision is not admissible")
+
+    if not parsed.get("proposed_output"):
+        return GateResult(False, "Candidate has no proposed output")
+
+    if parsed.get("requires_human_authorization") is not True:
+        return GateResult(False, "Candidate did not preserve human authorization requirement")
+
+    return GateResult(True)

--- a/tas_openai_bridge/ledger.py
+++ b/tas_openai_bridge/ledger.py
@@ -1,0 +1,14 @@
+"""In-memory paradata ledger sink for tests and local bridge wiring."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class InMemoryLedger:
+    records: list[Any] = field(default_factory=list)
+
+    def append(self, record: Any) -> None:
+        self.records.append(record)

--- a/tas_openai_bridge/perspective.py
+++ b/tas_openai_bridge/perspective.py
@@ -1,0 +1,199 @@
+"""Perspective Intelligence (π_i) kernel for TAS admissibility.
+
+The kernel encodes the rule of engagement:
+
+- No perspective without provenance.
+- No provenance without authority.
+- No authority without receipt.
+- No witnessed intent, no transformation.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+
+PHI = (1 + math.sqrt(5)) / 2
+
+
+class GateStatus(str, Enum):
+    """Terminal Perspective Intelligence gate states."""
+
+    ADMITTED = "ADMITTED"
+    REFUSED = "REFUSED"
+
+
+@dataclass(frozen=True)
+class PerspectiveOperator:
+    """Irrational observability operator for witnessed human intent."""
+
+    observer_locus: str
+    human_api_key_id: str
+    data_anchor: str
+    temporal_index: int
+    curvature_value: float
+
+    def has_observer_locus(self) -> bool:
+        try:
+            return bool(self.observer_locus.strip())
+        except (AttributeError, TypeError):
+            return False
+
+    def compute_curvature_ratio(self, authority_diameter: float) -> float:
+        try:
+            diameter = float(authority_diameter)
+            curvature = float(self.curvature_value)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("Authority diameter and curvature must be numeric.") from exc
+
+        if diameter <= 0:
+            raise ValueError("Authority diameter must be positive.")
+        return curvature / diameter
+
+
+@dataclass(frozen=True)
+class PerspectiveProvenanceReceipt:
+    """Minimal receipt trace required before perspective may enter state."""
+
+    receipt_id: str
+    identity_anchor: str
+    lineage_hash: str
+
+    def is_valid_trace(self) -> bool:
+        try:
+            return all(
+                [
+                    self.receipt_id.strip(),
+                    self.identity_anchor.strip(),
+                    self.lineage_hash.strip(),
+                ]
+            )
+        except (AttributeError, TypeError):
+            return False
+
+
+@dataclass(frozen=True)
+class LedgerAuthority:
+    """Authority diameter enforced by lineage, invariant law, and receipts."""
+
+    root_anchor: str
+    authority_diameter: float
+
+    def verifies(self, identity_anchor: str) -> bool:
+        try:
+            return bool(identity_anchor.strip()) and bool(self.root_anchor.strip())
+        except (AttributeError, TypeError):
+            return False
+
+
+@dataclass(frozen=True)
+class PerspectiveGateResult:
+    """Structured output of the Perspective Intelligence gate."""
+
+    status: GateStatus
+    reason: str
+    pi_i_ratio: float | None = None
+    receipt_id: str | None = None
+
+    @property
+    def admissible(self) -> bool:
+        return self.status is GateStatus.ADMITTED
+
+
+@dataclass(frozen=True)
+class PerspectiveContext:
+    """Convenience bundle for bridge-level perspective validation."""
+
+    pi_i: PerspectiveOperator
+    provenance_receipt: PerspectiveProvenanceReceipt
+    ledger_authority: LedgerAuthority
+    resonance_threshold: float = PHI
+
+
+def validate_perspective_operator(
+    pi_i: Any,
+    provenance_receipt: Any,
+    ledger_authority: Any,
+    resonance_threshold: float = PHI,
+) -> PerspectiveGateResult:
+    """Validate Perspective Intelligence before a transformation is admitted.
+
+    Truth is perspective-bound without being perspective-determined: witnessed
+    intent may introduce contextual curvature, but the Φ-bounded authority
+    diameter decides whether that curvature is structurally admissible.
+    """
+
+    try:
+        has_observer = bool(pi_i.has_observer_locus())
+    except (AttributeError, TypeError, ValueError):
+        has_observer = False
+
+    if not has_observer:
+        return PerspectiveGateResult(
+            status=GateStatus.REFUSED,
+            reason="Unwitnessed Intent Void",
+        )
+
+    try:
+        valid_trace = bool(provenance_receipt.is_valid_trace())
+    except (AttributeError, TypeError, ValueError):
+        valid_trace = False
+
+    if not valid_trace:
+        return PerspectiveGateResult(
+            status=GateStatus.REFUSED,
+            reason="No Perspective Without Provenance",
+        )
+
+    try:
+        verified = bool(ledger_authority.verifies(provenance_receipt.identity_anchor))
+    except (AttributeError, TypeError, ValueError):
+        verified = False
+
+    if not verified:
+        return PerspectiveGateResult(
+            status=GateStatus.REFUSED,
+            reason="No Provenance Without Authority",
+        )
+
+    try:
+        ratio = pi_i.compute_curvature_ratio(ledger_authority.authority_diameter)
+        threshold = float(resonance_threshold)
+    except (AttributeError, TypeError, ValueError) as exc:
+        return PerspectiveGateResult(
+            status=GateStatus.REFUSED,
+            reason=f"Invalid Authority Diameter: {exc}",
+        )
+
+    if ratio > threshold:
+        return PerspectiveGateResult(
+            status=GateStatus.REFUSED,
+            reason="Recursive Dissociation Threat - Exceeds Structural Bounds",
+            pi_i_ratio=ratio,
+        )
+
+    return PerspectiveGateResult(
+        status=GateStatus.ADMITTED,
+        reason="Perspective Intelligence Admitted",
+        pi_i_ratio=ratio,
+        receipt_id=provenance_receipt.receipt_id,
+    )
+
+
+def validate_perspective_context(context: Any) -> PerspectiveGateResult:
+    """Validate a bundled perspective context without raw-crashing."""
+
+    try:
+        return validate_perspective_operator(
+            context.pi_i,
+            context.provenance_receipt,
+            context.ledger_authority,
+            context.resonance_threshold,
+        )
+    except (AttributeError, TypeError, ValueError) as exc:
+        return PerspectiveGateResult(
+            status=GateStatus.REFUSED,
+            reason=f"Invalid Perspective Context: {exc}",
+        )

--- a/tas_openai_bridge/receipts.py
+++ b/tas_openai_bridge/receipts.py
@@ -1,0 +1,67 @@
+"""Receipt construction for TAS-OpenAI bridge executions."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from typing import Any
+
+
+def _safe_label(obj: Any, attr: str, default: str = "UNBOUND") -> str:
+    try:
+        value = getattr(obj, attr)
+    except (AttributeError, TypeError):
+        return default
+    if value is None:
+        return default
+    return str(value)
+
+
+def stable_hash(payload: Any) -> str:
+    """Return a deterministic SHA-256 hash for receipt payloads."""
+
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+@dataclass(frozen=True)
+class ProvenanceReceipt:
+    admissible: bool
+    action: str
+    receipt_hash: str
+    human_seed_status: str
+    authority_scope: str
+    model: str
+    response_id: str
+    gate: str
+    payload: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_response(
+        cls,
+        response: Any,
+        human_api_key: Any,
+        scoped_authority: Any,
+        gate_result: Any,
+        candidate: Any,
+    ) -> "ProvenanceReceipt":
+        payload = {
+            "candidate": candidate,
+            "gate": getattr(gate_result, "gate", "TAS_ADMISSIBILITY_GATEWAY"),
+            "model": _safe_label(response, "model"),
+            "response_id": _safe_label(response, "id"),
+            "human_seed_status": _safe_label(human_api_key, "key_id"),
+            "authority_scope": _safe_label(scoped_authority, "scope_id"),
+        }
+        return cls(
+            admissible=True,
+            action="ACCEPT_WITH_RECEIPT",
+            receipt_hash=stable_hash(payload),
+            human_seed_status=payload["human_seed_status"],
+            authority_scope=payload["authority_scope"],
+            model=payload["model"],
+            response_id=payload["response_id"],
+            gate=payload["gate"],
+            payload=payload,
+        )

--- a/tas_openai_bridge/refusal.py
+++ b/tas_openai_bridge/refusal.py
@@ -1,0 +1,24 @@
+"""Fail-closed refusal artifacts for the TAS-OpenAI bridge."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(frozen=True)
+class RefusalArtifact:
+    """Structured refusal emitted instead of raw-crashing or silently accepting."""
+
+    reason: str
+    action: str = "REFUSE"
+    admissible: bool = False
+    code: str = "TAS_OPENAI_REFUSAL"
+    details: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_gate_result(cls, gate_result: Any) -> "RefusalArtifact":
+        return cls(
+            reason=getattr(gate_result, "reason", "TAS gate refused candidate"),
+            details={"gate": getattr(gate_result, "gate", "unknown")},
+        )

--- a/tas_openai_bridge/schemas.py
+++ b/tas_openai_bridge/schemas.py
@@ -1,0 +1,62 @@
+"""Structured-output schema definitions for OpenAI Responses calls."""
+
+from __future__ import annotations
+
+TAS_CANDIDATE_RESPONSE_SCHEMA: dict = {
+    "type": "object",
+    "properties": {
+        "decision": {
+            "type": "string",
+            "enum": ["candidate", "refuse", "needs_more_context"],
+        },
+        "claim_type": {
+            "type": "string",
+            "enum": ["summary", "code", "analysis", "external_fact", "governance_action"],
+        },
+        "confidence": {"type": "number", "minimum": 0, "maximum": 1},
+        "requires_web_verification": {"type": "boolean"},
+        "requires_human_authorization": {"type": "boolean"},
+        "proposed_output": {"type": "string"},
+        "known_limitations": {"type": "array", "items": {"type": "string"}},
+        "tas_paradata": {
+            "type": "object",
+            "properties": {
+                "input_hash": {"type": "string"},
+                "model": {"type": "string"},
+                "timestamp": {"type": "string"},
+                "tool_path": {"type": "string"},
+                "receipt_required": {"type": "boolean"},
+            },
+            "required": [
+                "input_hash",
+                "model",
+                "timestamp",
+                "tool_path",
+                "receipt_required",
+            ],
+            "additionalProperties": False,
+        },
+    },
+    "required": [
+        "decision",
+        "claim_type",
+        "confidence",
+        "requires_web_verification",
+        "requires_human_authorization",
+        "proposed_output",
+        "known_limitations",
+        "tas_paradata",
+    ],
+    "additionalProperties": False,
+}
+
+
+def response_text_format() -> dict:
+    """Return the Responses API text.format payload for TAS candidates."""
+
+    return {
+        "type": "json_schema",
+        "name": "tas_candidate_response",
+        "strict": True,
+        "schema": TAS_CANDIDATE_RESPONSE_SCHEMA,
+    }

--- a/tests/test_perspective_intelligence.py
+++ b/tests/test_perspective_intelligence.py
@@ -1,0 +1,204 @@
+import pytest
+
+from tas_openai_bridge import (
+    GateStatus,
+    LedgerAuthority,
+    PerspectiveContext,
+    PerspectiveOperator,
+    PerspectiveProvenanceReceipt,
+    RefusalArtifact,
+    tas_openai_execute,
+    validate_perspective_context,
+    validate_perspective_operator,
+)
+import json
+from types import SimpleNamespace
+
+
+class HumanAPIKey:
+    key_id = "HumanAPIKey001"
+
+    def validate(self):
+        return True
+
+
+class ScopedAuthority:
+    def allows(self, operation):
+        return operation == "openai.responses.create"
+
+
+class FakeResponses:
+    def __init__(self, output_text):
+        self.output_text = output_text
+        self.calls = []
+
+    def create(self, **kwargs):
+        self.calls.append(kwargs)
+        return SimpleNamespace(id="resp_123", model=kwargs["model"], output_text=self.output_text)
+
+
+class FakeClient:
+    def __init__(self, output_text):
+        self.responses = FakeResponses(output_text)
+
+
+def candidate():
+    return json.dumps(
+        {
+            "decision": "candidate",
+            "claim_type": "analysis",
+            "confidence": 0.91,
+            "requires_web_verification": False,
+            "requires_human_authorization": True,
+            "proposed_output": "receipt-bearing perspective candidate",
+            "known_limitations": [],
+            "tas_paradata": {
+                "input_hash": "abc123",
+                "model": "gpt-5.5",
+                "timestamp": "2026-05-18T00:00:00Z",
+                "tool_path": "openai.responses",
+                "receipt_required": True,
+            },
+        }
+    )
+
+
+def valid_pi_i(curvature_value=1.0):
+    return PerspectiveOperator(
+        observer_locus="Russell Nordland",
+        human_api_key_id="HumanAPIKey001",
+        data_anchor="DATA_ANCHOR_001",
+        temporal_index=1,
+        curvature_value=curvature_value,
+    )
+
+
+def valid_receipt():
+    return PerspectiveProvenanceReceipt(
+        receipt_id="PI_I_RECEIPT_001",
+        identity_anchor="HumanAPIKey001",
+        lineage_hash="lineage_hash_001",
+    )
+
+
+def valid_authority(authority_diameter=1.0):
+    return LedgerAuthority(root_anchor="TAS_ROOT", authority_diameter=authority_diameter)
+
+
+def test_perspective_operator_admits_bounded_witnessed_intent():
+    result = validate_perspective_operator(valid_pi_i(), valid_receipt(), valid_authority())
+
+    assert result.status is GateStatus.ADMITTED
+    assert result.admissible is True
+    assert result.reason == "Perspective Intelligence Admitted"
+    assert result.pi_i_ratio == pytest.approx(1.0)
+    assert result.receipt_id == "PI_I_RECEIPT_001"
+
+
+def test_perspective_operator_refuses_unwitnessed_intent():
+    pi_i = PerspectiveOperator(
+        observer_locus="  ",
+        human_api_key_id="HumanAPIKey001",
+        data_anchor="DATA_ANCHOR_001",
+        temporal_index=1,
+        curvature_value=1.0,
+    )
+
+    result = validate_perspective_operator(pi_i, valid_receipt(), valid_authority())
+
+    assert result.status is GateStatus.REFUSED
+    assert result.admissible is False
+    assert result.reason == "Unwitnessed Intent Void"
+
+
+def test_perspective_operator_refuses_missing_provenance():
+    receipt = PerspectiveProvenanceReceipt(
+        receipt_id="",
+        identity_anchor="HumanAPIKey001",
+        lineage_hash="lineage_hash_001",
+    )
+
+    result = validate_perspective_operator(valid_pi_i(), receipt, valid_authority())
+
+    assert result.status is GateStatus.REFUSED
+    assert result.reason == "No Perspective Without Provenance"
+
+
+def test_perspective_operator_refuses_missing_authority():
+    authority = LedgerAuthority(root_anchor=" ", authority_diameter=1.0)
+
+    result = validate_perspective_operator(valid_pi_i(), valid_receipt(), authority)
+
+    assert result.status is GateStatus.REFUSED
+    assert result.reason == "No Provenance Without Authority"
+
+
+def test_perspective_operator_refuses_invalid_authority_diameter_without_crashing():
+    result = validate_perspective_operator(valid_pi_i(), valid_receipt(), valid_authority(authority_diameter=0))
+
+    assert result.status is GateStatus.REFUSED
+    assert result.reason.startswith("Invalid Authority Diameter")
+
+
+def test_perspective_operator_refuses_recursive_dissociation_threat():
+    result = validate_perspective_operator(valid_pi_i(curvature_value=2.0), valid_receipt(), valid_authority())
+
+    assert result.status is GateStatus.REFUSED
+    assert result.reason == "Recursive Dissociation Threat - Exceeds Structural Bounds"
+    assert result.pi_i_ratio == pytest.approx(2.0)
+
+
+def test_perspective_operator_wrong_types_refuse_without_raw_crash():
+    result = validate_perspective_operator(object(), object(), object())
+
+    assert result.status is GateStatus.REFUSED
+    assert result.reason == "Unwitnessed Intent Void"
+
+
+def test_perspective_context_refusal_blocks_openai_execution():
+    context = PerspectiveContext(
+        pi_i=valid_pi_i(curvature_value=2.0),
+        provenance_receipt=valid_receipt(),
+        ledger_authority=valid_authority(),
+    )
+    client = FakeClient(candidate())
+
+    result = tas_openai_execute(
+        HumanAPIKey(),
+        ScopedAuthority(),
+        "prompt",
+        client=client,
+        perspective_context=context,
+    )
+
+    assert isinstance(result, RefusalArtifact)
+    assert result.reason == "Recursive Dissociation Threat - Exceeds Structural Bounds"
+    assert result.details["gate"] == "Perspective Intelligence"
+    assert client.responses.calls == []
+
+
+def test_valid_perspective_context_allows_bridge_execution():
+    context = PerspectiveContext(
+        pi_i=valid_pi_i(),
+        provenance_receipt=valid_receipt(),
+        ledger_authority=valid_authority(),
+    )
+    client = FakeClient(candidate())
+
+    result = tas_openai_execute(
+        HumanAPIKey(),
+        ScopedAuthority(),
+        "prompt",
+        client=client,
+        perspective_context=context,
+    )
+
+    assert result.admissible is True
+    assert client.responses.calls
+
+
+def test_invalid_perspective_context_refuses_without_raw_crash():
+    result = validate_perspective_context(object())
+
+    assert result.status is GateStatus.REFUSED
+    assert result.reason.startswith("Invalid Perspective Context")

--- a/tests/test_tas_openai_bridge.py
+++ b/tests/test_tas_openai_bridge.py
@@ -1,0 +1,162 @@
+import json
+from types import SimpleNamespace
+
+from tas_openai_bridge import (
+    InMemoryLedger,
+    ProvenanceReceipt,
+    RefusalArtifact,
+    response_text_format,
+    stable_hash,
+    tas_openai_execute,
+)
+
+
+class HumanAPIKey:
+    key_id = "HumanAPIKey001"
+
+    def __init__(self, valid=True):
+        self.valid = valid
+
+    def validate(self):
+        return self.valid
+
+
+class ScopedAuthority:
+    scope_id = "TAS-OpenAI Bridge"
+
+    def __init__(self, allowed=True):
+        self.allowed = allowed
+
+    def allows(self, operation):
+        return self.allowed and operation == "openai.responses.create"
+
+
+class FakeResponses:
+    def __init__(self, output_text):
+        self.output_text = output_text
+        self.calls = []
+
+    def create(self, **kwargs):
+        self.calls.append(kwargs)
+        return SimpleNamespace(id="resp_123", model=kwargs["model"], output_text=self.output_text)
+
+
+class FakeClient:
+    def __init__(self, output_text):
+        self.responses = FakeResponses(output_text)
+
+
+def candidate(**overrides):
+    payload = {
+        "decision": "candidate",
+        "claim_type": "analysis",
+        "confidence": 0.91,
+        "requires_web_verification": False,
+        "requires_human_authorization": True,
+        "proposed_output": "receipt-bearing bridge candidate",
+        "known_limitations": [],
+        "tas_paradata": {
+            "input_hash": "abc123",
+            "model": "gpt-5.5",
+            "timestamp": "2026-05-15T00:00:00Z",
+            "tool_path": "openai.responses",
+            "receipt_required": True,
+        },
+    }
+    payload.update(overrides)
+    return json.dumps(payload)
+
+
+def test_none_human_api_key_refuses_without_crashing():
+    result = tas_openai_execute(None, ScopedAuthority(), "prompt", client=FakeClient(candidate()))
+
+    assert isinstance(result, RefusalArtifact)
+    assert result.admissible is False
+    assert result.reason == "Missing HumanAPI Key"
+
+
+def test_none_scoped_authority_refuses_without_crashing():
+    result = tas_openai_execute(HumanAPIKey(), None, "prompt", client=FakeClient(candidate()))
+
+    assert isinstance(result, RefusalArtifact)
+    assert result.admissible is False
+    assert result.reason == "Missing scoped authority"
+
+
+def test_wrong_type_authority_anchors_refuse_without_crashing():
+    result = tas_openai_execute(object(), object(), "prompt", client=FakeClient(candidate()))
+
+    assert isinstance(result, RefusalArtifact)
+    assert result.admissible is False
+    assert result.reason == "Invalid HumanAPI Key"
+
+
+def test_authority_validate_exception_refuses_without_crashing():
+    class ExplodingHumanAPIKey:
+        def validate(self):
+            raise AttributeError("broken anchor")
+
+    result = tas_openai_execute(ExplodingHumanAPIKey(), ScopedAuthority(), "prompt", client=FakeClient(candidate()))
+
+    assert isinstance(result, RefusalArtifact)
+    assert result.reason == "Invalid HumanAPI Key"
+
+
+def test_scope_denial_refuses_before_openai_execution():
+    client = FakeClient(candidate())
+    result = tas_openai_execute(HumanAPIKey(), ScopedAuthority(allowed=False), "prompt", client=client)
+
+    assert isinstance(result, RefusalArtifact)
+    assert result.reason == "Scope does not authorize OpenAI execution"
+    assert client.responses.calls == []
+
+
+def test_schema_required_for_openai_responses_call():
+    client = FakeClient(candidate())
+    result = tas_openai_execute(HumanAPIKey(), ScopedAuthority(), "prompt", client=client)
+
+    assert isinstance(result, ProvenanceReceipt)
+    text_format = client.responses.calls[0]["text"]["format"]
+    assert text_format == response_text_format()
+    assert text_format["type"] == "json_schema"
+    assert text_format["strict"] is True
+    assert "decision" in text_format["schema"]["required"]
+
+
+def test_gate_refusal_is_recorded_when_candidate_is_not_admissible():
+    ledger = InMemoryLedger()
+    result = tas_openai_execute(
+        HumanAPIKey(),
+        ScopedAuthority(),
+        "prompt",
+        client=FakeClient(candidate(decision="needs_more_context")),
+        ledger=ledger,
+    )
+
+    assert isinstance(result, RefusalArtifact)
+    assert result.reason == "Candidate decision is not admissible"
+    assert ledger.records == [result]
+
+
+def test_receipt_hash_stability():
+    payload = {"b": 2, "a": [1, 3]}
+
+    assert stable_hash(payload) == stable_hash({"a": [1, 3], "b": 2})
+
+
+def test_successful_candidate_returns_provenance_receipt_and_ledger_record():
+    ledger = InMemoryLedger()
+    result = tas_openai_execute(
+        HumanAPIKey(),
+        ScopedAuthority(),
+        "prompt",
+        client=FakeClient(candidate()),
+        ledger=ledger,
+    )
+
+    assert isinstance(result, ProvenanceReceipt)
+    assert result.admissible is True
+    assert result.action == "ACCEPT_WITH_RECEIPT"
+    assert result.human_seed_status == "HumanAPIKey001"
+    assert result.authority_scope == "TAS-OpenAI Bridge"
+    assert ledger.records == [result]

--- a/tests/test_tas_openai_bridge.py
+++ b/tests/test_tas_openai_bridge.py
@@ -3,6 +3,10 @@ from types import SimpleNamespace
 
 from tas_openai_bridge import (
     InMemoryLedger,
+    LedgerAuthority,
+    PerspectiveContext,
+    PerspectiveOperator,
+    PerspectiveProvenanceReceipt,
     ProvenanceReceipt,
     RefusalArtifact,
     response_text_format,
@@ -45,6 +49,23 @@ class FakeClient:
     def __init__(self, output_text):
         self.responses = FakeResponses(output_text)
 
+
+def valid_perspective_context():
+    return PerspectiveContext(
+        pi_i=PerspectiveOperator(
+            observer_locus="Russell Nordland",
+            human_api_key_id="HumanAPIKey001",
+            data_anchor="DATA_ANCHOR_001",
+            temporal_index=1,
+            curvature_value=1.0,
+        ),
+        provenance_receipt=PerspectiveProvenanceReceipt(
+            receipt_id="PI_I_RECEIPT_001",
+            identity_anchor="HumanAPIKey001",
+            lineage_hash="lineage_hash_001",
+        ),
+        ledger_authority=LedgerAuthority(root_anchor="TAS_ROOT", authority_diameter=1.0),
+    )
 
 def candidate(**overrides):
     payload = {
@@ -96,7 +117,12 @@ def test_authority_validate_exception_refuses_without_crashing():
         def validate(self):
             raise AttributeError("broken anchor")
 
-    result = tas_openai_execute(ExplodingHumanAPIKey(), ScopedAuthority(), "prompt", client=FakeClient(candidate()))
+    result = tas_openai_execute(
+        ExplodingHumanAPIKey(),
+        ScopedAuthority(),
+        "prompt",
+        client=FakeClient(candidate()),
+    )
 
     assert isinstance(result, RefusalArtifact)
     assert result.reason == "Invalid HumanAPI Key"
@@ -111,9 +137,24 @@ def test_scope_denial_refuses_before_openai_execution():
     assert client.responses.calls == []
 
 
-def test_schema_required_for_openai_responses_call():
+def test_missing_perspective_context_refuses_before_openai_execution():
     client = FakeClient(candidate())
     result = tas_openai_execute(HumanAPIKey(), ScopedAuthority(), "prompt", client=client)
+
+    assert isinstance(result, RefusalArtifact)
+    assert result.reason == "Unwitnessed Intent Void"
+    assert client.responses.calls == []
+
+
+def test_schema_required_for_openai_responses_call():
+    client = FakeClient(candidate())
+    result = tas_openai_execute(
+        HumanAPIKey(),
+        ScopedAuthority(),
+        "prompt",
+        client=client,
+        perspective_context=valid_perspective_context(),
+    )
 
     assert isinstance(result, ProvenanceReceipt)
     text_format = client.responses.calls[0]["text"]["format"]
@@ -131,6 +172,7 @@ def test_gate_refusal_is_recorded_when_candidate_is_not_admissible():
         "prompt",
         client=FakeClient(candidate(decision="needs_more_context")),
         ledger=ledger,
+        perspective_context=valid_perspective_context(),
     )
 
     assert isinstance(result, RefusalArtifact)
@@ -152,6 +194,7 @@ def test_successful_candidate_returns_provenance_receipt_and_ledger_record():
         "prompt",
         client=FakeClient(candidate()),
         ledger=ledger,
+        perspective_context=valid_perspective_context(),
     )
 
     assert isinstance(result, ProvenanceReceipt)


### PR DESCRIPTION
### Motivation
- Introduce a fail-closed bridge around OpenAI Responses that enforces a TAS admissibility gate and emits structured provenance receipts or refusal artifacts. 
- Provide deterministic receipt hashing and simple in-memory ledger support for local wiring and tests. 
- Make it easier to run the new tests locally by ignoring environment files and adjusting the test python path.

### Description
- Add a new `tas_openai_bridge` package implementing `tas_openai_execute` wrapper, deterministic `ProvenanceReceipt`, `RefusalArtifact`, `InMemoryLedger`, and the TAS admissibility gate in `gates.py`.
- Define a strict JSON schema `TAS_CANDIDATE_RESPONSE_SCHEMA` and `response_text_format()` for the OpenAI Responses `text.format` payload in `schemas.py`.
- Implement stable hashing via `stable_hash` and safe receipt construction in `receipts.py`, plus structured refusal creation in `refusal.py`.
- Add unit tests in `tests/test_tas_openai_bridge.py` covering authority validation, schema enforcement, gate refusals, receipt creation, ledger recording, and hash stability, and update project config by adding `.env` patterns to `.gitignore` and changing `pythonpath` in `pytest.ini` to include the repo root.

### Testing
- Ran the test suite with `pytest -q` targeting `tests/test_tas_openai_bridge.py`. 
- The automated unit tests (authority/anchor failure paths, schema enforcement, gate refusal recording, `ProvenanceReceipt` creation, `stable_hash` stability, and ledger appends) all succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a072e632d6c8333aa30ae591377dc70)