### PR TITLE
🧪 [Testing Improvement] Test OpenAI conduit execution failure handling

### DIFF
--- a/tests/tas_openai_bridge/test_client_exception_handling.py
+++ b/tests/tas_openai_bridge/test_client_exception_handling.py
@@ -1,0 +1,23 @@
+from tas_openai_bridge import HumanAPIKey, RefusalArtifact, ScopedAuthority, tas_openai_execute
+
+class RaisingClient:
+    @property
+    def responses(self):
+        class _Responses:
+            def create(self, **kwargs):
+                raise Exception("Network timeout")
+        return _Responses()
+
+def test_client_exception_emits_refusal():
+    result = tas_openai_execute(
+        HumanAPIKey("HumanAPIKey001"),
+        ScopedAuthority(authority="HumanAPIKey001"),
+        "draft a candidate",
+        client=RaisingClient(),
+    )
+
+    assert isinstance(result, RefusalArtifact)
+    assert result.reason == "OpenAI conduit execution failed"
+    assert result.details["stage"] == "openai.responses.create"
+    assert result.details["error"] == "Network timeout"
+# Nonce: 24374


### PR DESCRIPTION
🎯 **What:** The `tas_openai_execute` function in `bridge.py` gracefully catches `Exception`s originating from `client.responses.create` and correctly translates them into a `RefusalArtifact` indicating an execution failure.

📊 **Coverage:** A test file `tests/tas_openai_bridge/test_client_exception_handling.py` was introduced. It covers this exact error path by utilizing a stub `RaisingClient` that mocks the `responses.create` method and immediately raises an `Exception`. The test then verifies that a `RefusalArtifact` is returned holding the expected structural reasons and metadata.

✨ **Result:** Test coverage for the `tas_openai_bridge` package is improved. The `bridge.py` error handling mechanism is firmly established under regression protection, making potential refactoring safer.

---
*PR created automatically by Jules for task [17383799714110537756](https://jules.google.com/task/17383799714110537756) started by @TrueAlpha-spiral*