### PR TITLE
🧪 [testing improvement] Add exception handling test for admissibility gateway

### DIFF
--- a/tests/tas_openai_bridge/test_gates.py
+++ b/tests/tas_openai_bridge/test_gates.py
@@ -1,0 +1,15 @@
+from tas_openai_bridge.gates import tas_admissibility_gateway, GateResult
+
+class ExplodingDict(dict):
+    def __iter__(self):
+        raise RuntimeError("simulated exception")
+
+def test_admissibility_gateway_exception_handling():
+    payload = ExplodingDict()
+    result = tas_admissibility_gateway(payload)
+
+    assert isinstance(result, GateResult)
+    assert result.admissible is False
+    assert result.gate == "EXCEPTION"
+    assert "Unhandled exception in admissibility gateway: simulated exception" in result.reason
+# Nonce: 133892


### PR DESCRIPTION
🎯 **What:** Added test coverage for the generic exception handling block in `tas_admissibility_gateway`.
📊 **Coverage:** Added a test using a mock `ExplodingDict` that inherits from `dict` but raises an exception upon iteration, guaranteeing the `except Exception:` path is fully exercised.
✨ **Result:** Improved confidence that unexpected runtime errors within the gateway are properly encapsulated as `GateResult` failures rather than causing application crashes.

---
*PR created automatically by Jules for task [18379361322939225361](https://jules.google.com/task/18379361322939225361) started by @TrueAlpha-spiral*