### PR TITLE
🧪 [Testing improvement] Add test for unhandled exception in tas_openai_execute

### DIFF
--- a/tests/tas_openai_bridge/test_unhandled_exception.py
+++ b/tests/tas_openai_bridge/test_unhandled_exception.py
@@ -1,0 +1,32 @@
+from tas_openai_bridge import HumanAPIKey, RefusalArtifact, ScopedAuthority, tas_openai_execute
+
+def test_unhandled_runtime_exception_emits_refusal(monkeypatch):
+    import tas_openai_bridge.bridge
+
+    class MockResponse:
+        output_text = '{"some": "json"}'
+
+    class MockResponses:
+        def create(self, **kwargs):
+            return MockResponse()
+
+    class MockClient:
+        @property
+        def responses(self):
+            return MockResponses()
+
+    def exploding_gateway(*args, **kwargs):
+        raise RuntimeError("Synthetic gateway failure")
+
+    monkeypatch.setattr(tas_openai_bridge.bridge, "tas_admissibility_gateway", exploding_gateway)
+
+    result = tas_openai_execute(
+        HumanAPIKey("HumanAPIKey001"),
+        ScopedAuthority(authority="HumanAPIKey001"),
+        "draft a candidate",
+        client=MockClient(),
+    )
+
+    assert isinstance(result, RefusalArtifact)
+    assert result.reason == "Unhandled runtime exception in TAS bridge"
+    assert "Synthetic gateway failure" in result.details["error"]


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was testing generic exception handling in `tas_openai_execute`. We achieved this by patching `tas_admissibility_gateway` to raise a generic `RuntimeError` during execution.

📊 **Coverage:** The test ensures that if an arbitrary unhandled runtime exception is raised within the core function's execution body, it is safely caught by the broad `except Exception` block and converted into a valid `RefusalArtifact` containing the correct reason and stringified exception details, rather than crashing the runtime.

✨ **Result:** Improved safety net test coverage for the fail-closed generic exception boundary of `tas_openai_execute`. The test is fully deterministic and uses `monkeypatch` isolated to the single test function.

---
*PR created automatically by Jules for task [5454604548022720422](https://jules.google.com/task/5454604548022720422) started by @TrueAlpha-spiral*