### PR TITLE
🧪 [testing improvement] Cover generic exception in bridge execution

### DIFF
--- a/tests/tas_openai_bridge/test_fail_closed.py
+++ b/tests/tas_openai_bridge/test_fail_closed.py
@@ -1,4 +1,11 @@
-from tas_openai_bridge import RefusalArtifact, ScopedAuthority, tas_openai_execute
+from unittest.mock import patch
+import json
+from tas_openai_bridge import (
+    HumanAPIKey,
+    RefusalArtifact,
+    ScopedAuthority,
+    tas_openai_execute,
+)
 
 
 class ExplodingClient:
@@ -19,3 +26,49 @@ def test_none_human_api_key_emits_refusal_without_crash():
     assert result.action == "REFUSE"
     assert result.admissible is False
     assert result.reason == "Missing authority anchor"
+
+
+class MockResponse:
+    def __init__(self, output_text):
+        self.output_text = output_text
+
+
+class MockResponses:
+    def create(self, **kwargs):
+        return MockResponse(
+            json.dumps(
+                {
+                    "decision": "candidate",
+                    "claim_type": "analytical",
+                    "confidence": 0.9,
+                    "proposed_output": "test",
+                    "tas_paradata": {
+                        "tool_path": "openai.responses",
+                        "receipt_required": True,
+                    },
+                }
+            )
+        )
+
+
+class MockValidClient:
+    @property
+    def responses(self):
+        return MockResponses()
+
+
+@patch("tas_openai_bridge.bridge.tas_admissibility_gateway")
+def test_unhandled_exception_in_bridge_fails_closed(mock_gateway):
+    mock_gateway.side_effect = Exception("Simulated catastrophic failure")
+
+    result = tas_openai_execute(
+        HumanAPIKey("valid_key"),
+        ScopedAuthority("valid_key"),
+        "Test prompt",
+        client=MockValidClient(),
+    )
+
+    assert isinstance(result, RefusalArtifact)
+    assert result.reason == "Unhandled runtime exception in TAS bridge"
+    assert result.details["error"] == "Simulated catastrophic failure"
+# Nonce: 19126


### PR DESCRIPTION
🎯 What: Addresses testing gap for the global exception handler in tas_openai_execute.
📊 Coverage: Ensures a RefusalArtifact is generated instead of an unhandled crash when tas_admissibility_gateway raises an exception.
✨ Result: Increases reliability and safety guarantees of the fail-closed behavior in the OpenAI bridge.

---
*PR created automatically by Jules for task [11269612566683081130](https://jules.google.com/task/11269612566683081130) started by @TrueAlpha-spiral*