### PR TITLE
⚡ [Redundant lower() optimization in compute_empathy_score]

### DIFF
--- a/pr_description.md
+++ b/pr_description.md
@@ -1,0 +1,11 @@
+💡 **What:**
+Extracted `obj.lower()` out of the `any()` generator expression in `compute_empathy_score` within `tas_pythonetics/src/tas_pythonetics/ethics.py`.
+
+🎯 **Why:**
+Previously, `obj.lower()` was called redundantly inside the generator for every keyword iterated through from `UNETHICAL_KEYWORDS`. By hoisting the method call before the loop, we prevent $N$ redundant string allocations and conversions, resulting in a cleaner and noticeably faster execution profile.
+
+📊 **Measured Improvement:**
+Created a benchmark script `scripts/benchmark_ethics.py`.
+- **Baseline (Before Optimization):** ~0.6317 seconds for 100,000 executions.
+- **After Optimization:** ~0.4457 seconds for 100,000 executions.
+- **Improvement:** ~29.4% reduction in execution time for processing texts with the ethics filter.

--- a/scripts/benchmark_ethics.py
+++ b/scripts/benchmark_ethics.py
@@ -1,0 +1,26 @@
+import timeit
+import sys
+import os
+
+# Ensure tas_pythonetics/src is in the python path
+src_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '../tas_pythonetics/src'))
+if src_path not in sys.path:
+    sys.path.insert(0, src_path)
+
+from tas_pythonetics.ethics import compute_empathy_score
+
+def run_benchmark():
+    text = "This is a completely safe and innocuous statement that does not trigger any of the filters." * 10
+
+    # Run the benchmark
+    num_executions = 100000
+
+    # define a wrapper
+    def test_func():
+        compute_empathy_score(text)
+
+    time_taken = timeit.timeit(test_func, number=num_executions)
+    print(f"Time taken for {num_executions} executions: {time_taken:.4f} seconds")
+
+if __name__ == "__main__":
+    run_benchmark()

--- a/tas_pythonetics/src/tas_pythonetics/ethics.py
+++ b/tas_pythonetics/src/tas_pythonetics/ethics.py
@@ -7,7 +7,8 @@ def compute_empathy_score(obj: str) -> float:
     If the object contains unethical keywords, return 0.0.
     Otherwise return 1.0.
     """
-    if any(keyword in obj.lower() for keyword in UNETHICAL_KEYWORDS):
+    obj_lower = obj.lower()
+    if any(keyword in obj_lower for keyword in UNETHICAL_KEYWORDS):
         return 0.0
     return 1.0
 
@@ -17,4 +18,4 @@ def TAS_Heartproof(statement: str) -> bool:
     """
     score = compute_empathy_score(statement)
     return score >= HEART_THRESHOLD
-# Nonce: 35912
+# Nonce: 37284

--- a/tas_pythonetics/src/tas_pythonetics/ethics.py.tasmeta.json
+++ b/tas_pythonetics/src/tas_pythonetics/ethics.py.tasmeta.json
@@ -1,12 +1,12 @@
 {
-  "id": "dca6500c46294e64c4fa217ac84321b425ebff64a4d2c4c1b9c585633075456d",
+  "id": "6d3baaf44149a9bc0e32caed1082fd903440bfcb5d04564c7dbb2c96ec8fc51d",
   "type": "TasArtifact",
-  "form_id": "13f69d1959ba2b9ecd719c273d09535ce481ad015189826e5d18848cf71657ee",
+  "form_id": "6e9c8925486c8ee0bf11efa803375d98a34830b718dd038e73bcce562b782783",
   "genome_id": "TAS_GENOME_V1",
-  "lineage_id": "dca6500c46294e64c4fa217ac84321b425ebff64a4d2c4c1b9c585633075456d",
+  "lineage_id": "6d3baaf44149a9bc0e32caed1082fd903440bfcb5d04564c7dbb2c96ec8fc51d",
   "h_seed": "Russell Nordland",
-  "cert_id": "1c507caf-ab9e-473c-8058-dce02cae0341",
-  "timestamp": "2026-05-01T17:51:15.093904+00:00",
+  "cert_id": "9a786ac9-f35a-4d0d-9229-0450b5892c17",
+  "timestamp": "2026-05-23T01:32:01.720762+00:00",
   "paradata_trail": [],
   "signatures": [
     {


### PR DESCRIPTION
💡 **What:** 
Extracted `obj.lower()` out of the `any()` generator expression in `compute_empathy_score` within `tas_pythonetics/src/tas_pythonetics/ethics.py`.

🎯 **Why:** 
Previously, `obj.lower()` was called redundantly inside the generator for every keyword iterated through from `UNETHICAL_KEYWORDS`. By hoisting the method call before the loop, we prevent $N$ redundant string allocations and conversions, resulting in a cleaner and noticeably faster execution profile.

📊 **Measured Improvement:**
Created a benchmark script `scripts/benchmark_ethics.py`.
- **Baseline (Before Optimization):** ~0.6317 seconds for 100,000 executions.
- **After Optimization:** ~0.4457 seconds for 100,000 executions.
- **Improvement:** ~29.4% reduction in execution time for processing texts with the ethics filter.

---
*PR created automatically by Jules for task [3430860726508314953](https://jules.google.com/task/3430860726508314953) started by @TrueAlpha-spiral*