### PR TITLE
🧪 [test generic exception handling in bridge fail closed]

### DIFF
--- a/tests/tas_openai_bridge/test_fail_closed.py
+++ b/tests/tas_openai_bridge/test_fail_closed.py
@@ -1,4 +1,7 @@
 from tas_openai_bridge import RefusalArtifact, ScopedAuthority, tas_openai_execute
+from tas_openai_bridge.authority import HumanAPIKey
+from unittest.mock import patch
+import json
 
 
 class ExplodingClient:
@@ -19,3 +22,37 @@ def test_none_human_api_key_emits_refusal_without_crash():
     assert result.action == "REFUSE"
     assert result.admissible is False
     assert result.reason == "Missing authority anchor"
+
+
+class FakeResponse:
+    @property
+    def output_text(self):
+        return json.dumps({"structured": "data"})
+
+
+class FakeResponses:
+    def create(self, **kwargs):
+        return FakeResponse()
+
+
+class FakeClient:
+    @property
+    def responses(self):
+        return FakeResponses()
+
+
+@patch("tas_openai_bridge.bridge.tas_admissibility_gateway")
+def test_generic_exception_emits_refusal(mock_gateway):
+    mock_gateway.side_effect = Exception("Simulated unexpected gateway exception")
+
+    result = tas_openai_execute(
+        HumanAPIKey(key_id="HumanAPIKey001"),
+        ScopedAuthority(authority="HumanAPIKey001"),
+        "draft a candidate",
+        client=FakeClient(),
+    )
+
+    assert isinstance(result, RefusalArtifact)
+    assert result.reason == "Unhandled runtime exception in TAS bridge"
+    assert "error" in result.details
+    assert "Simulated unexpected gateway exception" in result.details["error"]


### PR DESCRIPTION
*   🎯 **What:** The testing gap addressed was testing the catch-all `except Exception as exc:` block in `tas_openai_execute` which ensures a generic crash gets properly converted into a `RefusalArtifact`.
*   📊 **Coverage:** A new test `test_generic_exception_emits_refusal` was added. It mocks `tas_admissibility_gateway` to throw a simulated exception and asserts that the bridge successfully intercepts it and fails closed with the appropriate refusal schema, rather than abruptly crashing.
*   ✨ **Result:** Enhanced unit test coverage for bridge fail-closed mechanics and runtime resilience.

---
*PR created automatically by Jules for task [3948744041583882115](https://jules.google.com/task/3948744041583882115) started by @TrueAlpha-spiral*