### PR TITLE
🧹 [code health improvement] Remove unused json import from scripts/itl_anchor.py

### DIFF
--- a/scripts/itl_anchor.py
+++ b/scripts/itl_anchor.py
@@ -1,4 +1,4 @@
-import hashlib, pathlib, json, datetime, requests
+import hashlib, pathlib, datetime, requests
 
 def sha_tree(root="tas_pythonetics"):
     h = hashlib.sha256()
@@ -16,4 +16,4 @@ payload = {
 # Replace with real TAS_ITL_API endpoint/token
 requests.post("https://tas.itl/anchor", json=payload)
 print("ITL anchor submitted:", payload["hash"])
-# Nonce: 176589
+# Nonce: 99166


### PR DESCRIPTION
🎯 **What:** Removed the unused `json` module import from `scripts/itl_anchor.py`.
💡 **Why:** The `json` module is not needed because `requests.post(..., json=payload)` automatically serializes the payload dictionary. Removing it cleans up the import statement and resolves linter warnings without changing functionality.
✅ **Verification:** Updated the Kinematic Identity (nonce) and ran the full pytest suite to verify no regressions were introduced.
✨ **Result:** A cleaner codebase with fewer unnecessary imports.

---
*PR created automatically by Jules for task [10660184943841488768](https://jules.google.com/task/10660184943841488768) started by @TrueAlpha-spiral*