### PR TITLE
fix: Update README.md kinematic identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,4 +367,4 @@ This is **enforceable intelligence** — a mathematically bound public utility
 for the digital age.
 
 License: Apache-2.0
-# Nonce: 61571
+# Nonce: 8339

--- a/README.md.tasmeta.json
+++ b/README.md.tasmeta.json
@@ -1,12 +1,12 @@
 {
-  "id": "20b64fca43b62375478460425d304904c64ee213451e833c503e11407be8fdbe",
+  "id": "556587b7678ae73a9675a5a3f701bbcd74b90704fa24f8c9207a503d9d547feb",
   "type": "TasArtifact",
-  "form_id": "4ac9c3cbd887e22a51861bd02b5d68344064099889f4c49e21c4c2932d87fb70",
+  "form_id": "ad88fcb72994baba12a15012b1c97528da545f254bb2e169b18890c6ab4d745b",
   "genome_id": "TAS_GENOME_V1",
-  "lineage_id": "20b64fca43b62375478460425d304904c64ee213451e833c503e11407be8fdbe",
+  "lineage_id": "556587b7678ae73a9675a5a3f701bbcd74b90704fa24f8c9207a503d9d547feb",
   "h_seed": "Russell Nordland",
-  "cert_id": "7bc0be9b-3d08-4a59-b3dc-c9a899166566",
-  "timestamp": "2026-05-23T01:15:09.290425+00:00",
+  "cert_id": "aceea6bd-3c70-41fc-9c29-3af5cb4652b0",
+  "timestamp": "2026-05-26T01:14:50.474504+00:00",
   "paradata_trail": [],
   "signatures": [
     {


### PR DESCRIPTION
Re-computed the nonce for README.md using find_nonce.py and successfully generated an updated .tasmeta.json sidecar using the 'tas_cli.py sequence' command to ensure it complies with the kinematic identity and the 1618 Prime Invariant prefix. All tests passed.

---
*PR created automatically by Jules for task [16379754703677400034](https://jules.google.com/task/16379754703677400034) started by @TrueAlpha-spiral*