### PR TITLE
🧹 Remove unused import importlib.machinery in test_higgs_fix.py

### DIFF
--- a/tests/test_higgs_fix.py
+++ b/tests/test_higgs_fix.py
@@ -1,6 +1,5 @@
 import pytest
 import importlib.util
-import importlib.machinery
 import os
 import sys
 import unittest.mock
@@ -54,4 +53,4 @@ def test_run_command_prevents_injection():
         assert args_passed[0] == ["echo", "hello;", "rm", "-rf", "/"], "shlex.split should properly tokenize"
     finally:
         subprocess.Popen = original_popen
-# Nonce: 96641
+# Nonce: 295670


### PR DESCRIPTION
🎯 **What:** Removed the unused import `import importlib.machinery` from `tests/test_higgs_fix.py`.

💡 **Why:** Unused imports clutter the codebase and can cause confusion. Removing them improves code readability and maintainability.

✅ **Verification:** I ran the specific test `pytest tests/test_higgs_fix.py` and the full test suite using `pytest` to ensure no regressions were introduced. Additionally, the pre-commit script `code_review.py` passed successfully.

✨ **Result:** The code health of `tests/test_higgs_fix.py` is improved without any change in functionality.

---
*PR created automatically by Jules for task [9537432121709025725](https://jules.google.com/task/9537432121709025725) started by @TrueAlpha-spiral*