### PR TITLE
🧪 Add unit tests for ITL anchor script using dynamic mocks

### DIFF
--- a/scripts/itl_anchor.py.tasmeta.json
+++ b/scripts/itl_anchor.py.tasmeta.json
@@ -1,12 +1,12 @@
 {
-  "id": "8256cfd6e233210b9f6fa55e000af0fa87f270c4945432deb7a84adc6a6581f4",
+  "id": "ccd60737b220334e6d11b4b44ddb3ed2dd49a9fb4c173765978ef8c43c71ecdf",
   "type": "TasArtifact",
   "form_id": "68d48f831568726df07b9c7d6f76883d05817c46af009b5a08cea73ebe92dd4d",
   "genome_id": "TAS_GENOME_V1",
-  "lineage_id": "8256cfd6e233210b9f6fa55e000af0fa87f270c4945432deb7a84adc6a6581f4",
+  "lineage_id": "ccd60737b220334e6d11b4b44ddb3ed2dd49a9fb4c173765978ef8c43c71ecdf",
   "h_seed": "Russell Nordland",
-  "cert_id": "f6a1796b-df8e-477e-815e-7699a7844a16",
-  "timestamp": "2026-05-28T01:21:07.038815+00:00",
+  "cert_id": "2f088085-d42f-49ea-aebd-816db370f676",
+  "timestamp": "2026-05-30T01:13:50.264505+00:00",
   "paradata_trail": [],
   "signatures": [
     {

--- a/tests/test_itl_anchor.py
+++ b/tests/test_itl_anchor.py
@@ -1,0 +1,50 @@
+import pytest
+import os
+import sys
+import unittest.mock
+import importlib.util
+
+def load_itl_anchor():
+    script_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "scripts", "itl_anchor.py"))
+
+    loader = importlib.machinery.SourceFileLoader("itl_anchor", script_path)
+    spec = importlib.util.spec_from_loader("itl_anchor", loader)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["itl_anchor"] = module
+
+    requests_mock = unittest.mock.MagicMock()
+    sys.modules["requests"] = requests_mock
+    sys.modules["requests.exceptions"] = unittest.mock.MagicMock()
+
+    return module, loader, requests_mock
+
+def test_itl_anchor_success():
+    module, loader, requests_mock = load_itl_anchor()
+
+    mock_response = unittest.mock.MagicMock()
+    requests_mock.post.return_value = mock_response
+
+    loader.exec_module(module)
+
+    requests_mock.post.assert_called_once()
+    args, kwargs = requests_mock.post.call_args
+    assert args[0] == "https://tas.itl/anchor"
+    assert "json" in kwargs
+    assert "timeout" in kwargs
+    assert kwargs["timeout"] == 10
+    assert "hash" in kwargs["json"]
+    assert "author" in kwargs["json"]
+
+    mock_response.raise_for_status.assert_called_once()
+
+def test_itl_anchor_failure():
+    module, loader, requests_mock = load_itl_anchor()
+
+    mock_response = unittest.mock.MagicMock()
+    mock_response.raise_for_status.side_effect = Exception("HTTP Error")
+    requests_mock.post.return_value = mock_response
+
+    with pytest.raises(Exception, match="HTTP Error"):
+        loader.exec_module(module)
+
+# Nonce: 33623

--- a/tests/test_itl_anchor.py
+++ b/tests/test_itl_anchor.py
@@ -3,6 +3,12 @@ import os
 import sys
 import unittest.mock
 import importlib.util
+import importlib.machinery
+
+@pytest.fixture(autouse=True)
+def clean_sys_modules():
+    with unittest.mock.patch.dict(sys.modules):
+        yield
 
 def load_itl_anchor():
     script_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "scripts", "itl_anchor.py"))


### PR DESCRIPTION
🎯 **What:**
Added unit tests for `scripts/itl_anchor.py` inside `tests/test_itl_anchor.py`. Since `scripts/itl_anchor.py` uses `requests` and executes network calls at the top level when imported, the tests use `importlib` and `sys.modules` patching to inject mock objects before execution. This ensures the script can be fully tested even when `requests` is unavailable in the environment.

💡 **Why:**
This improves test coverage and verifies that the `itl_anchor.py` script correctly formulates the payload and issues the appropriate network calls with a proper timeout, ensuring network hang vulnerability mitigation.

✅ **Verification:**
Tests are executed using `pytest` with proper `PYTHONPATH` structure. The entire test suite was successfully run, confirming no regressions.

✨ **Result:**
Test coverage has increased, and regression testing for the ITL anchor functionality is now possible without relying on external network dependencies or the presence of the `requests` library.

---
*PR created automatically by Jules for task [13870845275460809610](https://jules.google.com/task/13870845275460809610) started by @TrueAlpha-spiral*