### PR TITLE
🔒 [security] Apply TrueAlphaSpiral standards to unsequenced scripts

### DIFF
--- a/scripts/benchmark_ethics.py.tasmeta.json
+++ b/scripts/benchmark_ethics.py.tasmeta.json
@@ -1,0 +1,18 @@
+{
+  "id": "79aa59c426f3e704aca3638e793e83b8188f9f39b97cfcb90449f04320b9e92a",
+  "type": "TasArtifact",
+  "form_id": "c72a63ca85c0e04d508c9c9b77b993ca0e1b4b2e046381efb421ee44c0165b53",
+  "genome_id": "TAS_GENOME_V1",
+  "lineage_id": "79aa59c426f3e704aca3638e793e83b8188f9f39b97cfcb90449f04320b9e92a",
+  "h_seed": "Russell Nordland",
+  "cert_id": "ed9e87c1-2a03-4811-a299-fc9babb78c50",
+  "timestamp": "2026-06-04T01:34:38.127092+00:00",
+  "paradata_trail": [],
+  "signatures": [
+    {
+      "signer": "Russell Nordland",
+      "algorithm": "TAS_HUMAN_SIG_V1",
+      "value": "signed_by_ceremony"
+    }
+  ]
+}

--- a/scripts/tasverify.py.tasmeta.json
+++ b/scripts/tasverify.py.tasmeta.json
@@ -1,0 +1,18 @@
+{
+  "id": "64be13349fcbe61434d5eea21e52eceffbf6640104f651431b639c3a37ad3c43",
+  "type": "TasArtifact",
+  "form_id": "19f1210b6a8de58e463c4048642d9e2df9c47eaa83824dc0a52bfd45c832903c",
+  "genome_id": "TAS_GENOME_V1",
+  "lineage_id": "64be13349fcbe61434d5eea21e52eceffbf6640104f651431b639c3a37ad3c43",
+  "h_seed": "Russell Nordland",
+  "cert_id": "a3e02cbd-bca1-438a-852d-d0beb552782c",
+  "timestamp": "2026-06-04T01:34:46.837439+00:00",
+  "paradata_trail": [],
+  "signatures": [
+    {
+      "signer": "Russell Nordland",
+      "algorithm": "TAS_HUMAN_SIG_V1",
+      "value": "signed_by_ceremony"
+    }
+  ]
+}

--- a/tas_pythonetics/src/tas_pythonetics/ethics.py.tasmeta.json
+++ b/tas_pythonetics/src/tas_pythonetics/ethics.py.tasmeta.json
@@ -1,12 +1,12 @@
 {
-  "id": "6d3baaf44149a9bc0e32caed1082fd903440bfcb5d04564c7dbb2c96ec8fc51d",
+  "id": "cd954ab885c83c4419cc57cd1b657ce9e082c44dfa77ba65bc507b2abf54caef",
   "type": "TasArtifact",
   "form_id": "6e9c8925486c8ee0bf11efa803375d98a34830b718dd038e73bcce562b782783",
   "genome_id": "TAS_GENOME_V1",
-  "lineage_id": "6d3baaf44149a9bc0e32caed1082fd903440bfcb5d04564c7dbb2c96ec8fc51d",
+  "lineage_id": "cd954ab885c83c4419cc57cd1b657ce9e082c44dfa77ba65bc507b2abf54caef",
   "h_seed": "Russell Nordland",
-  "cert_id": "9a786ac9-f35a-4d0d-9229-0450b5892c17",
-  "timestamp": "2026-05-23T01:32:01.720762+00:00",
+  "cert_id": "1d9acf29-95cd-4e51-a78a-fef168d04fe3",
+  "timestamp": "2026-06-04T01:29:49.672805+00:00",
   "paradata_trail": [],
   "signatures": [
     {


### PR DESCRIPTION
🎯 **What:**
Sequenced `scripts/benchmark_ethics.py` and `scripts/tasverify.py` using `tas_cli.py sequence` to enforce TrueAlphaSpiral (TAS) architecture standards.
Created the `.tasmeta.json` metadata sidecars for these unsequenced files.
There were no network calls in the newly sequenced scripts, so no explicit network timeouts were needed to be added.

⚠️ **Risk:**
Unsequenced files lack cryptographic identity sidecars, exposing them to tampering without breaking the TrueAlphaSpiral lineage loop.

🛡️ **Solution:**
Generated `.tasmeta.json` sequence files via `tas_cli.py sequence` to track their Kinematic Identity and enforce immutable architectural rules on these previously unprotected artifacts.

---
*PR created automatically by Jules for task [9686565510711055302](https://jules.google.com/task/9686565510711055302) started by @TrueAlpha-spiral*