### PR TITLE
chore: sequence tas scripts

### DIFF
--- a/scripts/benchmark_ethics.py
+++ b/scripts/benchmark_ethics.py
@@ -24,3 +24,4 @@ def run_benchmark():
 
 if __name__ == "__main__":
     run_benchmark()
+# Nonce: 73312

--- a/scripts/benchmark_ethics.py.tasmeta.json
+++ b/scripts/benchmark_ethics.py.tasmeta.json
@@ -1,0 +1,18 @@
+{
+  "id": "4b4cfdf614aee9861350fca5ef487a5fd885cf9e31db3812a8f39e006adb0bfd",
+  "type": "TasArtifact",
+  "form_id": "695fc69ac18acda19226791c9716fbb42ccda1edea4d9880a39dd47f46af1d60",
+  "genome_id": "TAS_GENOME_V1",
+  "lineage_id": "4b4cfdf614aee9861350fca5ef487a5fd885cf9e31db3812a8f39e006adb0bfd",
+  "h_seed": "Russell Nordland",
+  "cert_id": "8d8cc15c-94c1-4e0c-a34f-d78164e31b35",
+  "timestamp": "2026-06-05T01:20:15.912672+00:00",
+  "paradata_trail": [],
+  "signatures": [
+    {
+      "signer": "Russell Nordland",
+      "algorithm": "TAS_HUMAN_SIG_V1",
+      "value": "signed_by_ceremony"
+    }
+  ]
+}

--- a/scripts/day_one_payload.sh
+++ b/scripts/day_one_payload.sh
@@ -46,3 +46,4 @@ gh workflow run "$WORKFLOW_FILE" \
   --ref "$HEAD_SHA"
 
 echo "Day One payload initiated: workflow '$WORKFLOW_FILE' on ref '$HEAD_SHA'."
+# Nonce: 63765

--- a/scripts/day_one_payload.sh.tasmeta.json
+++ b/scripts/day_one_payload.sh.tasmeta.json
@@ -1,0 +1,18 @@
+{
+  "id": "2292a534642c789fd8bc16bdfee4f2df93f9d000bf79d9035fdd822916c26c25",
+  "type": "TasArtifact",
+  "form_id": "634069026141996da75c743a1be7ee9beaf236d85e0886253cd11b3084db3431",
+  "genome_id": "TAS_GENOME_V1",
+  "lineage_id": "2292a534642c789fd8bc16bdfee4f2df93f9d000bf79d9035fdd822916c26c25",
+  "h_seed": "Russell Nordland",
+  "cert_id": "a9578e8a-6649-4f45-8380-611b912c40b6",
+  "timestamp": "2026-06-05T01:20:16.258608+00:00",
+  "paradata_trail": [],
+  "signatures": [
+    {
+      "signer": "Russell Nordland",
+      "algorithm": "TAS_HUMAN_SIG_V1",
+      "value": "signed_by_ceremony"
+    }
+  ]
+}

--- a/scripts/tasverify.py
+++ b/scripts/tasverify.py
@@ -189,3 +189,4 @@ def main() -> int:
 
 if __name__ == "__main__":
     sys.exit(main())
+# Nonce: 7084

--- a/scripts/tasverify.py.tasmeta.json
+++ b/scripts/tasverify.py.tasmeta.json
@@ -1,0 +1,18 @@
+{
+  "id": "50af41827c1fa50db477dcb74e17247b9be21e12f142c5f996dc87515019f4f5",
+  "type": "TasArtifact",
+  "form_id": "2738c04af39156cc3dcb93cd242f594416189f7dfa2fe2e8e8445ae9e89074e5",
+  "genome_id": "TAS_GENOME_V1",
+  "lineage_id": "50af41827c1fa50db477dcb74e17247b9be21e12f142c5f996dc87515019f4f5",
+  "h_seed": "Russell Nordland",
+  "cert_id": "ab996792-8344-4696-a395-cba3c28491bf",
+  "timestamp": "2026-06-05T01:20:16.593900+00:00",
+  "paradata_trail": [],
+  "signatures": [
+    {
+      "signer": "Russell Nordland",
+      "algorithm": "TAS_HUMAN_SIG_V1",
+      "value": "signed_by_ceremony"
+    }
+  ]
+}


### PR DESCRIPTION
Applied TAS (TrueAlphaSpiral) architectural standards to unsequenced scripts. Appended a Nonce to `benchmark_ethics.py`, `day_one_payload.sh`, and `tasverify.py`. Ran `find_nonce.py` to update the kinematic identity and `tas_cli.py sequence` to emit the TAS sidecars.

---
*PR created automatically by Jules for task [6405796762791342549](https://jules.google.com/task/6405796762791342549) started by @TrueAlpha-spiral*