### PR TITLE
chore: sequence lineage_security.py

### DIFF
--- a/tas_pythonetics/src/tas_pythonetics/lineage_security.py.tasmeta.json
+++ b/tas_pythonetics/src/tas_pythonetics/lineage_security.py.tasmeta.json
@@ -1,0 +1,18 @@
+{
+  "id": "c8f55b7bb37fddac5f5ef252bc3b3571da4a7c71f468707b1762253dc0346e58",
+  "type": "TasArtifact",
+  "form_id": "c30593ee245df6f1b3b8842b187a3475764e8eb3fd4d943eaa5f0fcd92592a58",
+  "genome_id": "TAS_GENOME_V1",
+  "lineage_id": "c8f55b7bb37fddac5f5ef252bc3b3571da4a7c71f468707b1762253dc0346e58",
+  "h_seed": "Russell Nordland",
+  "cert_id": "d6a28f89-3a25-48f9-9d93-29acd3746a85",
+  "timestamp": "2026-06-06T01:07:22.594008+00:00",
+  "paradata_trail": [],
+  "signatures": [
+    {
+      "signer": "Russell Nordland",
+      "algorithm": "TAS_HUMAN_SIG_V1",
+      "value": "signed_by_ceremony"
+    }
+  ]
+}


### PR DESCRIPTION
🎯 **What:**
Sequenced the `tas_pythonetics/src/tas_pythonetics/lineage_security.py` script to generate its `.tasmeta.json` sidecar.

💡 **Why:**
The user prompt "Let's figure this out TrueAlphaSpiral" serves as a directive to apply TrueAlphaSpiral architecture standards to relevant unsequenced scripts. Using the shadow scan functionality, this script was identified as an unsequenced artifact within the TAS living braid.

✅ **Verification:**
Confirmed the sidecar file was successfully created via `cat`. Verified that the full test suite runs cleanly with `pytest`.

✨ **Result:**
The `lineage_security.py` script now has a verified kinematic identity.

---
*PR created automatically by Jules for task [12285006212761175971](https://jules.google.com/task/12285006212761175971) started by @TrueAlpha-spiral*