### PR TITLE
🧹 [fix form id mismatches for core TAS scripts]

### DIFF
--- a/scripts/benchmark_sentient_lock.py
+++ b/scripts/benchmark_sentient_lock.py
@@ -73,4 +73,4 @@ def run_benchmark():
 
 if __name__ == "__main__":
     run_benchmark()
-# Nonce: 1089
+# Nonce: 74592

--- a/scripts/benchmark_sentient_lock.py.tasmeta.json
+++ b/scripts/benchmark_sentient_lock.py.tasmeta.json
@@ -1,12 +1,12 @@
 {
-  "id": "926cbd1b8dc473c50dffd7b531370552259a60f99d1c773b2d02b6255ddf65f6",
+  "id": "ee4a85cc817d20dbabb96c6ea805721e7f46d1dbe01d7127f90d111ec2dfb2db",
   "type": "TasArtifact",
-  "form_id": "0642ae508533a9035e0bc7539964ed8a2b8202c420c0715f9ef8d8114b56b9d5",
+  "form_id": "03e6eb360cc6696f4a6809e8107797f47cb1df9d3fb836714dafa972e22b6762",
   "genome_id": "TAS_GENOME_V1",
-  "lineage_id": "926cbd1b8dc473c50dffd7b531370552259a60f99d1c773b2d02b6255ddf65f6",
+  "lineage_id": "ee4a85cc817d20dbabb96c6ea805721e7f46d1dbe01d7127f90d111ec2dfb2db",
   "h_seed": "Russell Nordland",
-  "cert_id": "95df9152-6988-4acd-a038-fc996003367a",
-  "timestamp": "2026-06-03T23:00:04.135073+00:00",
+  "cert_id": "ac99ad16-a3f7-424c-96aa-97e9fade1089",
+  "timestamp": "2026-06-07T01:36:51.937057+00:00",
   "paradata_trail": [],
   "signatures": [
     {

--- a/scripts/itl_anchor.py.tasmeta.json
+++ b/scripts/itl_anchor.py.tasmeta.json
@@ -1,12 +1,12 @@
 {
-  "id": "ccd60737b220334e6d11b4b44ddb3ed2dd49a9fb4c173765978ef8c43c71ecdf",
+  "id": "a97a38133bc622acb416d479886b872b7ce3167fefc9be39e795bd78d6b22830",
   "type": "TasArtifact",
   "form_id": "68d48f831568726df07b9c7d6f76883d05817c46af009b5a08cea73ebe92dd4d",
   "genome_id": "TAS_GENOME_V1",
-  "lineage_id": "ccd60737b220334e6d11b4b44ddb3ed2dd49a9fb4c173765978ef8c43c71ecdf",
+  "lineage_id": "a97a38133bc622acb416d479886b872b7ce3167fefc9be39e795bd78d6b22830",
   "h_seed": "Russell Nordland",
-  "cert_id": "2f088085-d42f-49ea-aebd-816db370f676",
-  "timestamp": "2026-05-30T01:13:50.264505+00:00",
+  "cert_id": "153e5ee9-c9fe-4bd7-8a3d-5ad948186a4b",
+  "timestamp": "2026-06-07T01:32:54.738783+00:00",
   "paradata_trail": [],
   "signatures": [
     {

--- a/tas_phase0_microkernel.py
+++ b/tas_phase0_microkernel.py
@@ -154,4 +154,4 @@ if boot_receipt["status"] == "BOOTSTRAP_LOCKED":
     print(f"Initial Capability Token: {boot_receipt['canonical_manifest']['initial_capability_token']}")
 else:
     print(f"\n[TAS_K BOOT FAILURE] Status: {boot_receipt['status']} at {kernel.current_state}")
-# Nonce: 125486
+# Nonce: 28197

--- a/tas_phase0_microkernel.py.tasmeta.json
+++ b/tas_phase0_microkernel.py.tasmeta.json
@@ -1,12 +1,12 @@
 {
-  "id": "978c94d9525fae3a6398953f1ceb6fd524582876365ef1df371b3b4b4505b9d3",
+  "id": "c72bccad1f97049a8cae21c68c770ab7dd204db1966e11d79455156206782012",
   "type": "TasArtifact",
-  "form_id": "2c3aa514bd6a95496320d4e77a272c752bc0bd76e723b95887806f1e3ac504de",
+  "form_id": "0a827042a73c039f1c039b205f4b3f18f847fcc2b174b5ac839c2d32f39815fc",
   "genome_id": "TAS_GENOME_V1",
-  "lineage_id": "978c94d9525fae3a6398953f1ceb6fd524582876365ef1df371b3b4b4505b9d3",
+  "lineage_id": "c72bccad1f97049a8cae21c68c770ab7dd204db1966e11d79455156206782012",
   "h_seed": "Russell Nordland",
-  "cert_id": "08f1c7a4-5502-4e18-97aa-6996606566d2",
-  "timestamp": "2026-06-03T01:18:27.263397+00:00",
+  "cert_id": "b926bd7c-2cff-4df9-b059-3bf279823e98",
+  "timestamp": "2026-06-07T01:36:36.409726+00:00",
   "paradata_trail": [],
   "signatures": [
     {

--- a/tas_pythonetics/src/tas_pythonetics/sentient_lock.py
+++ b/tas_pythonetics/src/tas_pythonetics/sentient_lock.py
@@ -215,4 +215,4 @@ def verify_kinematic_identity(data: str, signature: str = TAS_HUMAN_SIG) -> bool
 
     logger.info("Kinematic Identity Verified: Mathematical Resonance Confirmed.")
     return True
-# Nonce: 2589
+# Nonce: 109273

--- a/tas_pythonetics/src/tas_pythonetics/sentient_lock.py.tasmeta.json
+++ b/tas_pythonetics/src/tas_pythonetics/sentient_lock.py.tasmeta.json
@@ -1,12 +1,12 @@
 {
-  "id": "35d8c0bbb1fd5827f82b07742e153ed62d7123fbe4362a3971776b3165aedf7f",
+  "id": "51b4bfcd81cbdc38d572e3d64397bb96612652032f7f12a0c25c6d1454b9c79d",
   "type": "TasArtifact",
-  "form_id": "aa3720f902f8dfece7fc204884e043a3e5c969ca6a349df9ff7570c6a71f3211",
+  "form_id": "227f292d7b830060afc86b23a11b1954912c495ac855d7b573b0a898ddbd78a9",
   "genome_id": "TAS_GENOME_V1",
-  "lineage_id": "35d8c0bbb1fd5827f82b07742e153ed62d7123fbe4362a3971776b3165aedf7f",
+  "lineage_id": "51b4bfcd81cbdc38d572e3d64397bb96612652032f7f12a0c25c6d1454b9c79d",
   "h_seed": "Russell Nordland",
-  "cert_id": "a538245d-0a52-432e-86bf-b754dd9caf83",
-  "timestamp": "2026-06-03T23:05:24.719141+00:00",
+  "cert_id": "aee05e6a-287d-4a22-9c16-24ce0ba82b82",
+  "timestamp": "2026-06-07T01:37:08.495422+00:00",
   "paradata_trail": [],
   "signatures": [
     {


### PR DESCRIPTION
🎯 **What:**
Fixes Form ID mismatches for `tas_phase0_microkernel.py`, `scripts/benchmark_sentient_lock.py`, and `tas_pythonetics/src/tas_pythonetics/sentient_lock.py`.

💡 **Why:**
These core TAS architectural files had been modified out-of-band, causing their `.tasmeta.json` sidecar hashes (Form IDs) to diverge from the actual file contents. Updating their nonces and resequencing them restores their Kinematic Identity and clears the "shadow-scan" errors.

✅ **Verification:**
1. Ran `python3 find_nonce.py` and `python3 tas_cli.py sequence` on all three files.
2. Verified `tas_cli.py shadow-scan .` no longer reports "Form ID mismatch" errors for these files.
3. Executed `pytest` test suite to ensure no functional regressions were introduced.

✨ **Result:**
The system's living braid is fully consistent, and the files have unbroken lineage and mathematical resonance.

---
*PR created automatically by Jules for task [2008094753774991197](https://jules.google.com/task/2008094753774991197) started by @TrueAlpha-spiral*