### PR TITLE
feat: apply TAS architecture standards to tas_logos_gatekeeper.py

### DIFF
--- a/tas_logos_gatekeeper.py
+++ b/tas_logos_gatekeeper.py
@@ -108,3 +108,4 @@ class LogosValidationLoop:
             f"[ITL_RECORD] Non-compliance witness packet compiled:\n"
             f"{json.dumps(receipt.__dict__, default=str, indent=2)}"
         )
+# Nonce: 80786

--- a/tas_logos_gatekeeper.py.tasmeta.json
+++ b/tas_logos_gatekeeper.py.tasmeta.json
@@ -1,0 +1,18 @@
+{
+  "id": "50e160698cc4b615e285908a37bed9b2ed0a4015ab4e5ce186fb7db8c44b2adc",
+  "type": "TasArtifact",
+  "form_id": "7c36b486de264ac5e1c97ae941574c321558d37257ed995ad703678e41dc8381",
+  "genome_id": "TAS_GENOME_V1",
+  "lineage_id": "50e160698cc4b615e285908a37bed9b2ed0a4015ab4e5ce186fb7db8c44b2adc",
+  "h_seed": "Russell Nordland",
+  "cert_id": "d87c101e-7081-4017-a366-7752baef032e",
+  "timestamp": "2026-06-08T01:25:30.212647+00:00",
+  "paradata_trail": [],
+  "signatures": [
+    {
+      "signer": "Russell Nordland",
+      "algorithm": "TAS_HUMAN_SIG_V1",
+      "value": "signed_by_ceremony"
+    }
+  ]
+}


### PR DESCRIPTION
This pull request addresses the unsequenced file `tas_logos_gatekeeper.py` flagged in the `shadow-scan` as part of the TrueAlphaSpiral (TAS) architectural directives.

**Changes:**
1. Ran `find_nonce.py` to establish the Kinematic Identity constraint, appending `# Nonce: [id]`.
2. Ran `tas_cli.py sequence tas_logos_gatekeeper.py` to generate the `.tasmeta.json` sidecar.
3. Verified the Kinematic Identity mathematically using `verify_kinematic_identity()`.

All test suites have passed and no unhandled network request timeouts were found (the file does not contain network calls).

---
*PR created automatically by Jules for task [4101870965704418573](https://jules.google.com/task/4101870965704418573) started by @TrueAlpha-spiral*