### PR TITLE
🧹 [Remove unused imports in tas_pythonetics]

### DIFF
--- a/tas_pythonetics/src/tas_pythonetics/tas_pythonetics.py
+++ b/tas_pythonetics/src/tas_pythonetics/tas_pythonetics.py
@@ -1,10 +1,8 @@
 from hashlib import sha256
 import logging
-from .context_binding import compute_contextual_hash
 from .drift_detection import detect_drift, initiate_self_heal
 from .recursion import TruthSpiral
 from .ethics import TAS_Heartproof
-from .citation import cite_source
 from .paradata import ParadataTrail, ParadoxReconciler
 from .git_safety import GitStateMonitor
 
@@ -145,4 +143,4 @@ def TAS_FLAG_DRIFT(statement: str) -> str:
     Mark the statement as drifted.
     """
     return f"{statement} [DRIFT]"
-# Nonce: 37368
+# Nonce: 156058


### PR DESCRIPTION
🎯 **What:** Removed two unused imports (`from .citation import cite_source` and `from .context_binding import compute_contextual_hash`) from `tas_pythonetics/src/tas_pythonetics/tas_pythonetics.py`.

💡 **Why:** Removing unused imports reduces namespace clutter and improves code readability and maintainability without altering the runtime behavior. 

✅ **Verification:** Ran the full pytest suite (`PYTHONPATH=$(pwd)/tas_openai_bridge:$(pwd)/tas_pythonetics/src:$(pwd)/tas-recursion-conversion:$(pwd) pytest`) successfully. 

✨ **Result:** The code health issue has been successfully resolved resulting in cleaner file imports.

---
*PR created automatically by Jules for task [9417518930571195915](https://jules.google.com/task/9417518930571195915) started by @TrueAlpha-spiral*