### PR TITLE
🧪 [testing improvement] Test tas_sequencer.py calculate_sha256

### DIFF
--- a/pr_description.md
+++ b/pr_description.md
@@ -1,11 +1,3 @@
-💡 **What:**
-Extracted `obj.lower()` out of the `any()` generator expression in `compute_empathy_score` within `tas_pythonetics/src/tas_pythonetics/ethics.py`.
-
-🎯 **Why:**
-Previously, `obj.lower()` was called redundantly inside the generator for every keyword iterated through from `UNETHICAL_KEYWORDS`. By hoisting the method call before the loop, we prevent $N$ redundant string allocations and conversions, resulting in a cleaner and noticeably faster execution profile.
-
-📊 **Measured Improvement:**
-Created a benchmark script `scripts/benchmark_ethics.py`.
-- **Baseline (Before Optimization):** ~0.6317 seconds for 100,000 executions.
-- **After Optimization:** ~0.4457 seconds for 100,000 executions.
-- **Improvement:** ~29.4% reduction in execution time for processing texts with the ethics filter.
+🎯 **What:** Adding unit tests for the `calculate_sha256` function in `tas_tools/tas_sequencer.py`.
+📊 **Coverage:** Added explicit testing for valid file parsing, handling of large files (exceeding the standard 64KB read chunk size), and proper error handling logic (catching the exception and returning `None`) for non-existent missing files.
+✨ **Result:** Improved test coverage across standard IO functions inside the `tas_sequencer`, ensuring proper file IO hash generation without unhandled errors.

--- a/submit_payload.json
+++ b/submit_payload.json
@@ -1,0 +1,5 @@
+{
+  "branch": "test-calculate-sha256-tas-sequencer",
+  "pr_title": "🧪 [testing improvement] Test tas_sequencer.py calculate_sha256",
+  "pr_body": "🎯 **What:** Adding unit tests for the `calculate_sha256` function in `tas_tools/tas_sequencer.py`.\n📊 **Coverage:** Added explicit testing for valid file parsing, handling of large files (exceeding the standard 64KB read chunk size), and proper error handling logic (catching the exception and returning `None`) for non-existent missing files.\n✨ **Result:** Improved test coverage across standard IO functions inside the `tas_sequencer`, ensuring proper file IO hash generation without unhandled errors."
+}

--- a/tests/test_tas_sequencer.py
+++ b/tests/test_tas_sequencer.py
@@ -1,10 +1,5 @@
-import os
 import hashlib
-import sys
 from pathlib import Path
-
-# Adjust PYTHONPATH just in case
-sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from tas_tools.tas_sequencer import calculate_sha256
 

--- a/tests/test_tas_sequencer.py
+++ b/tests/test_tas_sequencer.py
@@ -1,0 +1,36 @@
+import os
+import hashlib
+import sys
+from pathlib import Path
+
+# Adjust PYTHONPATH just in case
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from tas_tools.tas_sequencer import calculate_sha256
+
+def test_calculate_sha256_valid_file(tmp_path):
+    test_file = tmp_path / "test.txt"
+    content = b"hello world"
+    test_file.write_bytes(content)
+
+    expected_hash = hashlib.sha256(content).hexdigest()
+    result = calculate_sha256(str(test_file))
+
+    assert result == expected_hash
+
+def test_calculate_sha256_large_file(tmp_path):
+    test_file = tmp_path / "large.txt"
+    content = b"a" * 100000
+    test_file.write_bytes(content)
+
+    expected_hash = hashlib.sha256(content).hexdigest()
+    result = calculate_sha256(str(test_file))
+
+    assert result == expected_hash
+
+def test_calculate_sha256_missing_file(tmp_path):
+    non_existent_file = tmp_path / "missing.txt"
+    result = calculate_sha256(str(non_existent_file))
+
+    assert result is None
+# Nonce: 236255

--- a/tests/test_tas_sequencer.py.tasmeta.json
+++ b/tests/test_tas_sequencer.py.tasmeta.json
@@ -1,0 +1,18 @@
+{
+  "id": "025719a03aa678530a80afacfeddd0415c1f4310175895b6c4f6c08a0b79c24a",
+  "type": "TasArtifact",
+  "form_id": "e4331e9dada9c2842a35312f4d1371ff3fa277e6b3a724e4893b9fc7202cbf88",
+  "genome_id": "TAS_GENOME_V1",
+  "lineage_id": "025719a03aa678530a80afacfeddd0415c1f4310175895b6c4f6c08a0b79c24a",
+  "h_seed": "Russell Nordland",
+  "cert_id": "e7708038-65e1-4f40-8e85-23f8ad447edf",
+  "timestamp": "2026-06-08T03:22:04.665014+00:00",
+  "paradata_trail": [],
+  "signatures": [
+    {
+      "signer": "Russell Nordland",
+      "algorithm": "TAS_HUMAN_SIG_V1",
+      "value": "signed_by_ceremony"
+    }
+  ]
+}


### PR DESCRIPTION
🎯 **What:** Adding unit tests for the `calculate_sha256` function in `tas_tools/tas_sequencer.py`.
📊 **Coverage:** Added explicit testing for valid file parsing, handling of large files (exceeding the standard 64KB read chunk size), and proper error handling logic (catching the exception and returning `None`) for non-existent missing files.
✨ **Result:** Improved test coverage across standard IO functions inside the `tas_sequencer`, ensuring proper file IO hash generation without unhandled errors.

---
*PR created automatically by Jules for task [1746375518726847787](https://jules.google.com/task/1746375518726847787) started by @TrueAlpha-spiral*