### PR TITLE
🧹 [Refactor from_iterables to use AuthorityConfig]

### DIFF
--- a/tas_openai_bridge/__init__.py
+++ b/tas_openai_bridge/__init__.py
@@ -10,7 +10,7 @@ from .gates import GateResult, tas_admissibility_gateway
 from .receipts import ProvenanceReceipt
 from .refusal import RefusalArtifact
 from .schemas import TAS_CANDIDATE_RESPONSE_SCHEMA, CandidateResponse
-from .authority import HumanAPIKey, ScopedAuthority
+from .authority import HumanAPIKey, ScopedAuthority, AuthorityConfig
 from .trinity import (
     ArchetypeAnalysis,
     OctopusArchetype,
@@ -34,6 +34,7 @@ __all__ = [
     "SafetyEnvelope",
     "SemanticRouter",
     "ScopedAuthority",
+    "AuthorityConfig",
     "SingularityEvent",
     "TAS_CANDIDATE_RESPONSE_SCHEMA",
     "TrinityEngine",

--- a/tas_openai_bridge/authority.py
+++ b/tas_openai_bridge/authority.py
@@ -18,6 +18,20 @@ class HumanAPIKey:
 
 
 @dataclass(frozen=True)
+class AuthorityConfig:
+    """Configuration grouping optional parameters for ScopedAuthority."""
+
+    conduit: str = "openai"
+    scope: list[str] | tuple[str, ...] = ("openai.responses.create",)
+    forbidden: list[str] | tuple[str, ...] = (
+        "final_authority_without_receipt",
+        "silent_tool_execution",
+    )
+    expires_at: datetime | None = None
+    active: bool = True
+
+
+@dataclass(frozen=True)
 class ScopedAuthority:
     """Bounded conduit authority for a specific execution surface."""
 
@@ -35,27 +49,23 @@ class ScopedAuthority:
     def from_iterables(
         cls,
         authority: str,
-        conduit: str = "openai",
-        scope: list[str] | tuple[str, ...] = ("openai.responses.create",),
-        forbidden: list[str] | tuple[str, ...] = (
-            "final_authority_without_receipt",
-            "silent_tool_execution",
-        ),
-        expires_at: datetime | None = None,
-        active: bool = True,
+        config: AuthorityConfig | None = None,
     ) -> "ScopedAuthority":
+        config = config or AuthorityConfig()
         return cls(
             authority=authority,
-            conduit=conduit,
-            scope=tuple(scope),
-            forbidden=tuple(forbidden),
-            expires_at=expires_at,
-            active=active,
+            conduit=config.conduit,
+            scope=tuple(config.scope),
+            forbidden=tuple(config.forbidden),
+            expires_at=config.expires_at,
+            active=config.active,
         )
 
     def allows(self, action: str) -> bool:
         if not self.active or self.conduit != "openai":
             return False
-        if self.expires_at is not None and self.expires_at <= datetime.now(timezone.utc):
+        if self.expires_at is not None and self.expires_at <= datetime.now(
+            timezone.utc
+        ):
             return False
         return action in self.scope and action not in self.forbidden

--- a/tests/tas_openai_bridge/test_none_authority_refuses.py
+++ b/tests/tas_openai_bridge/test_none_authority_refuses.py
@@ -1,4 +1,10 @@
-from tas_openai_bridge import HumanAPIKey, RefusalArtifact, ScopedAuthority, tas_openai_execute
+from tas_openai_bridge import (
+    HumanAPIKey,
+    RefusalArtifact,
+    ScopedAuthority,
+    AuthorityConfig,
+    tas_openai_execute,
+)
 
 
 def test_none_scoped_authority_refuses():
@@ -28,7 +34,9 @@ def test_invalid_human_api_key_refuses():
 def test_scope_without_openai_responses_refuses():
     result = tas_openai_execute(
         HumanAPIKey("HumanAPIKey001"),
-        ScopedAuthority.from_iterables("HumanAPIKey001", scope=["draft"]),
+        ScopedAuthority.from_iterables(
+            "HumanAPIKey001", config=AuthorityConfig(scope=["draft"])
+        ),
         "draft a candidate",
         client=object(),
     )
@@ -40,7 +48,9 @@ def test_scope_without_openai_responses_refuses():
 def test_missing_openai_sdk_refuses_when_default_client_needed(monkeypatch):
     import importlib.util
 
-    monkeypatch.setattr(importlib.util, "find_spec", lambda name: None if name == "openai" else object())
+    monkeypatch.setattr(
+        importlib.util, "find_spec", lambda name: None if name == "openai" else object()
+    )
 
     result = tas_openai_execute(
         HumanAPIKey("HumanAPIKey001"),

--- a/tests/tas_openai_bridge/test_polymath.py
+++ b/tests/tas_openai_bridge/test_polymath.py
@@ -5,6 +5,7 @@ from tas_openai_bridge import (
     HumanAPIKey,
     RefusalArtifact,
     ScopedAuthority,
+    AuthorityConfig,
 )
 from tas_openai_bridge.ledger import ImmutableTruthLedger
 
@@ -85,7 +86,7 @@ def test_malformed_scope_refuses():
     polymath = AlgorithmicPolymath(
         human_api_key=HumanAPIKey("HumanAPIKey001"),
         scoped_authority=ScopedAuthority.from_iterables(
-            "HumanAPIKey001", scope=["draft"]
+            "HumanAPIKey001", config=AuthorityConfig(scope=["draft"])
         ),
         lineage_anchor="valid_anchor",
         ledger=ImmutableTruthLedger(),


### PR DESCRIPTION
🎯 **What:** Refactored `ScopedAuthority.from_iterables` to take a new `AuthorityConfig` dataclass instead of multiple parameters.
💡 **Why:** Resolves the "Too many parameters" issue by grouping optional arguments into a configuration object, improving readability and maintainability while preserving type hints.
✅ **Verification:** Ran format checks (`black`), static analysis (`mypy`), and verified that the entire `pytest` test suite passes successfully.
✨ **Result:** Cleaner method signature in `ScopedAuthority` that maintains strict typing and default values.

---
*PR created automatically by Jules for task [9331968119060235720](https://jules.google.com/task/9331968119060235720) started by @TrueAlpha-spiral*