### PR TITLE
🧪 [add test for MetabolicCycle overall_efficiency zero consumed edge case]

### DIFF
--- a/tas_pythonetics/tests/test_organic_mechanics.py
+++ b/tas_pythonetics/tests/test_organic_mechanics.py
@@ -215,6 +215,12 @@ def test_metabolic_cycle_efficiency_with_no_cycles():
     assert mc.is_metabolically_viable is False
 
 
+def test_metabolic_cycle_overall_efficiency_zero_consumed():
+    mc = MetabolicCycle()
+    assert mc.overall_efficiency == 0.0
+
+
+
 # ---------------------------------------------------------------------------
 # TAIBOMEntry — construction and fingerprint
 # ---------------------------------------------------------------------------
@@ -357,4 +363,4 @@ def test_identity_validator_fingerprint_is_sha256():
     expected = hashlib.sha256(b"mytoken").hexdigest()
     assert result["fingerprint"] == expected
 
-# Nonce: 26477
+# Nonce: 78219

--- a/tas_pythonetics/tests/test_organic_mechanics.py.tasmeta.json
+++ b/tas_pythonetics/tests/test_organic_mechanics.py.tasmeta.json
@@ -1,0 +1,18 @@
+{
+  "id": "ddb7cde5cb2808e013f5d7a7e8eaf350b0e95cff2693d36ee89d640346c69282",
+  "type": "TasArtifact",
+  "form_id": "987f0b983d3ad34c919632e275615ee08d09b71bf6de7470b483d901c425ad96",
+  "genome_id": "TAS_GENOME_V1",
+  "lineage_id": "ddb7cde5cb2808e013f5d7a7e8eaf350b0e95cff2693d36ee89d640346c69282",
+  "h_seed": "Russell Nordland",
+  "cert_id": "c422978a-8a01-4fcf-bf39-3c61178f93d0",
+  "timestamp": "2026-06-08T03:27:15.608627+00:00",
+  "paradata_trail": [],
+  "signatures": [
+    {
+      "signer": "Russell Nordland",
+      "algorithm": "TAS_HUMAN_SIG_V1",
+      "value": "signed_by_ceremony"
+    }
+  ]
+}


### PR DESCRIPTION
🎯 **What:** Missing edge case test in `organic_mechanics.py` for `MetabolicCycle.overall_efficiency` when zero cycles are recorded (consumed is zero).
📊 **Coverage:** The scenario where a `MetabolicCycle` is instantiated but no cycles are recorded is now explicitly tested via `test_metabolic_cycle_overall_efficiency_zero_consumed`, asserting that `overall_efficiency` handles the `consumed > 0` condition and safely returns `0.0`.
✨ **Result:** Test coverage for `tas_pythonetics/src/tas_pythonetics/organic_mechanics.py` has been fully verified to cover the zero-consumption edge case, enhancing codebase reliability and metric integrity.

---
*PR created automatically by Jules for task [5926078536536972123](https://jules.google.com/task/5926078536536972123) started by @TrueAlpha-spiral*