### PR TITLE
🧹 [Resolve Deprecation Warning]

### DIFF
--- a/scripts/itl_anchor.py
+++ b/scripts/itl_anchor.py
@@ -10,7 +10,7 @@ def sha_tree(root="tas_pythonetics"):
 payload = {
     "hash": sha_tree(),
     "author": "Russell Nordland",
-    "timestamp": datetime.datetime.utcnow().isoformat() + "Z",
+    "timestamp": datetime.datetime.now(datetime.timezone.utc).isoformat().replace("+00:00", "Z"),
     "version": "0.1.0",
 }
 # Replace with real TAS_ITL_API endpoint/token

--- a/scripts/itl_anchor.py.tasmeta.json
+++ b/scripts/itl_anchor.py.tasmeta.json
@@ -1,12 +1,12 @@
 {
-  "id": "a97a38133bc622acb416d479886b872b7ce3167fefc9be39e795bd78d6b22830",
+  "id": "c2274c449395f48b33145f12f4107e28efe6dc24f62350fc518f471fef026079",
   "type": "TasArtifact",
-  "form_id": "68d48f831568726df07b9c7d6f76883d05817c46af009b5a08cea73ebe92dd4d",
+  "form_id": "c66bd7b20fb340b5e48cf67401bec6b579a19bafd9737ba5212f29203bd9497a",
   "genome_id": "TAS_GENOME_V1",
-  "lineage_id": "a97a38133bc622acb416d479886b872b7ce3167fefc9be39e795bd78d6b22830",
+  "lineage_id": "c2274c449395f48b33145f12f4107e28efe6dc24f62350fc518f471fef026079",
   "h_seed": "Russell Nordland",
-  "cert_id": "153e5ee9-c9fe-4bd7-8a3d-5ad948186a4b",
-  "timestamp": "2026-06-07T01:32:54.738783+00:00",
+  "cert_id": "b2e0871d-fbb3-456d-ada9-4be0c53d328a",
+  "timestamp": "2026-06-11T01:29:29.862162+00:00",
   "paradata_trail": [],
   "signatures": [
     {

--- a/tas-recursion-conversion/tas_governance/core/invariants/sovereign_innovation.py.tasmeta.json
+++ b/tas-recursion-conversion/tas_governance/core/invariants/sovereign_innovation.py.tasmeta.json
@@ -1,12 +1,12 @@
 {
-  "id": "615ff7aa526e55675c75809bfdfd93674d4439f5c5ac9581dd4ea48e1ef366f9",
+  "id": "a135c3601f12db9f5aa6ac4effd1f7aaf28815f2d5b606ce627d0b09b67927d6",
   "type": "TasArtifact",
-  "form_id": "e7a093c038fcf0101f6db296f1844381d0fa8d66753767b9c7d2c92c723f97db",
+  "form_id": "b5c0d8eb88fb3cc07d1215fd2b03e52f22fb3889b49221b591120b76f71a6651",
   "genome_id": "TAS_GENOME_V1",
-  "lineage_id": "615ff7aa526e55675c75809bfdfd93674d4439f5c5ac9581dd4ea48e1ef366f9",
+  "lineage_id": "a135c3601f12db9f5aa6ac4effd1f7aaf28815f2d5b606ce627d0b09b67927d6",
   "h_seed": "Russell Nordland",
-  "cert_id": "8c3b325b-4bc9-4420-965f-7b66560b44a0",
-  "timestamp": "2026-05-28T01:26:12.147481+00:00",
+  "cert_id": "5ff19ff9-7f1d-4429-bdc1-696842b54b46",
+  "timestamp": "2026-06-11T01:24:49.906716+00:00",
   "paradata_trail": [],
   "signatures": [
     {

--- a/tas_pythonetics/src/tas_pythonetics/ethics.py.tasmeta.json
+++ b/tas_pythonetics/src/tas_pythonetics/ethics.py.tasmeta.json
@@ -1,12 +1,12 @@
 {
-  "id": "6230ee4acb2b5e2ed0d67d7906803a8572a2a3551e4d60f37de244b5b293c027",
+  "id": "272c97847e17fc7ff0fc44701ab0a6baa126917c0ddef839419198088e97ca8e",
   "type": "TasArtifact",
-  "form_id": "56c0c57689ceaa3e5d310b3a1fd07a66e83b080235a5b79464c10cc4387b5d27",
+  "form_id": "296780a4f40b0f0a74e649b51f9d0bd088b7d906daf6f81e86993246dc84e57c",
   "genome_id": "TAS_GENOME_V1",
-  "lineage_id": "6230ee4acb2b5e2ed0d67d7906803a8572a2a3551e4d60f37de244b5b293c027",
+  "lineage_id": "272c97847e17fc7ff0fc44701ab0a6baa126917c0ddef839419198088e97ca8e",
   "h_seed": "Russell Nordland",
-  "cert_id": "fe1e2b78-1c1b-4774-8d33-e5e039d2e965",
-  "timestamp": "2026-06-09T01:26:54.864488+00:00",
+  "cert_id": "762041b3-468d-41bf-a86e-d9fd74cc95f5",
+  "timestamp": "2026-06-11T01:24:54.481741+00:00",
   "paradata_trail": [],
   "signatures": [
     {

--- a/tas_pythonetics/src/tas_pythonetics/paradata.py.tasmeta.json
+++ b/tas_pythonetics/src/tas_pythonetics/paradata.py.tasmeta.json
@@ -1,12 +1,12 @@
 {
-  "id": "8587407ebdb0af2b6f4a2c1f598378ea374814ed1ce293b1791f4e898220744a",
+  "id": "095ed2004c88c747c3402442e57e9cece7b17d52356c448a3308256553aa9ccd",
   "type": "TasArtifact",
-  "form_id": "fc151483336316fba8410bcd88f6413f4ce2d53fa83ff284851b8fb6b7180a81",
+  "form_id": "4de5257f20e33e7da90eb3676d8d430d07709a3aea906e9b17cfa4ed9bb492e5",
   "genome_id": "TAS_GENOME_V1",
-  "lineage_id": "8587407ebdb0af2b6f4a2c1f598378ea374814ed1ce293b1791f4e898220744a",
+  "lineage_id": "095ed2004c88c747c3402442e57e9cece7b17d52356c448a3308256553aa9ccd",
   "h_seed": "Russell Nordland",
-  "cert_id": "e0e74a59-eb01-4dab-a608-f026eb16cc5d",
-  "timestamp": "2026-05-01T17:51:15.395424+00:00",
+  "cert_id": "6389f198-04f1-4aad-9be6-28995d41a537",
+  "timestamp": "2026-06-11T01:24:58.988245+00:00",
   "paradata_trail": [],
   "signatures": [
     {

--- a/tas_pythonetics/tests/test_organic_mechanics.py.tasmeta.json
+++ b/tas_pythonetics/tests/test_organic_mechanics.py.tasmeta.json
@@ -1,12 +1,12 @@
 {
-  "id": "aa5d063c66eadb0543f883faf38c00c32b0b3d7b1656d8c5fe0f3a109ecd4141",
+  "id": "119ddf87cd1d1d0fbd2284fee7e379ecbf507f81647532b4e96dd6947709cee0",
   "type": "TasArtifact",
-  "form_id": "025217933129ee8f2b683305be9206570046b0929b6f76a78302df33b1fbd267",
+  "form_id": "8a1b70c6a72db26aa43265a917412367ea46ef25d3a26b3b30d98a7826195228",
   "genome_id": "TAS_GENOME_V1",
-  "lineage_id": "aa5d063c66eadb0543f883faf38c00c32b0b3d7b1656d8c5fe0f3a109ecd4141",
+  "lineage_id": "119ddf87cd1d1d0fbd2284fee7e379ecbf507f81647532b4e96dd6947709cee0",
   "h_seed": "Russell Nordland",
-  "cert_id": "62f7c27b-5e7c-4884-b2ef-07ddad1375c4",
-  "timestamp": "2026-06-08T03:26:29.788126+00:00",
+  "cert_id": "d9c28464-a673-429d-afcb-2fa169ed12fd",
+  "timestamp": "2026-06-11T01:25:09.250433+00:00",
   "paradata_trail": [],
   "signatures": [
     {


### PR DESCRIPTION
🎯 **What:** Replace deprecated `datetime.datetime.utcnow()`.
💡 **Why:** Improve maintainability and remove warnings in Python 3.12+.
✅ **Verification:** Test suite passes with no warnings.
✨ **Result:** Code health is improved, and invalid ISO timestamps are prevented.

---
*PR created automatically by Jules for task [14260682308954034493](https://jules.google.com/task/14260682308954034493) started by @TrueAlpha-spiral*