### PR TITLE
🧹 [Fix datetime deprecation warning in itl_anchor.py]

### DIFF
--- a/scripts/itl_anchor.py
+++ b/scripts/itl_anchor.py
@@ -10,11 +10,11 @@ def sha_tree(root="tas_pythonetics"):
 payload = {
     "hash": sha_tree(),
     "author": "Russell Nordland",
-    "timestamp": datetime.datetime.utcnow().isoformat() + "Z",
+    "timestamp": datetime.datetime.now(datetime.timezone.utc).isoformat().replace("+00:00", "Z"),
     "version": "0.1.0",
 }
 # Replace with real TAS_ITL_API endpoint/token
 response = requests.post("https://tas.itl/anchor", json=payload, timeout=10)
 response.raise_for_status()
 print("ITL anchor submitted:", payload["hash"])
-# Nonce: 10478
+# Nonce: 15767

--- a/scripts/itl_anchor.py
+++ b/scripts/itl_anchor.py
@@ -10,7 +10,7 @@ def sha_tree(root="tas_pythonetics"):
 payload = {
     "hash": sha_tree(),
     "author": "Russell Nordland",
-    "timestamp": datetime.datetime.now(datetime.timezone.utc).isoformat().replace("+00:00", "Z"),
+    "timestamp": datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None).isoformat() + "Z",
     "version": "0.1.0",
 }
 # Replace with real TAS_ITL_API endpoint/token

--- a/scripts/itl_anchor.py.tasmeta.json
+++ b/scripts/itl_anchor.py.tasmeta.json
@@ -1,12 +1,12 @@
 {
-  "id": "a97a38133bc622acb416d479886b872b7ce3167fefc9be39e795bd78d6b22830",
+  "id": "8c15141aad81e0947b13f31dc8539c3253cd1cceb711ec9988763fec47311d3d",
   "type": "TasArtifact",
-  "form_id": "68d48f831568726df07b9c7d6f76883d05817c46af009b5a08cea73ebe92dd4d",
+  "form_id": "148029ec4d5fa641582fffd8453ddac47e403d9277bff3cb97705817df66a494",
   "genome_id": "TAS_GENOME_V1",
-  "lineage_id": "a97a38133bc622acb416d479886b872b7ce3167fefc9be39e795bd78d6b22830",
+  "lineage_id": "8c15141aad81e0947b13f31dc8539c3253cd1cceb711ec9988763fec47311d3d",
   "h_seed": "Russell Nordland",
-  "cert_id": "153e5ee9-c9fe-4bd7-8a3d-5ad948186a4b",
-  "timestamp": "2026-06-07T01:32:54.738783+00:00",
+  "cert_id": "a0cc0655-e8f3-4ac8-8e64-239a422c034d",
+  "timestamp": "2026-06-12T01:23:57.173659+00:00",
   "paradata_trail": [],
   "signatures": [
     {


### PR DESCRIPTION
🎯 **What:** Resolved the `DeprecationWarning` in `scripts/itl_anchor.py` caused by `datetime.datetime.utcnow()`.
💡 **Why:** To maintain code health, ensure forward compatibility with Python 3.12+, and resolve continuous integration test warnings while keeping strict compatibility with exact ISO 8601 formatting required by downstream APIs.
✅ **Verification:** Verified by checking that `pytest` runs correctly without triggering `DeprecationWarning`s. Also ensured the kinematic identity was regenerated securely.
✨ **Result:** A safer, correctly formatted script with zero warnings.

---
*PR created automatically by Jules for task [11412010681012969492](https://jules.google.com/task/11412010681012969492) started by @TrueAlpha-spiral*