### PR TITLE
🧹 [Fix Python 3.12 datetime deprecation in threshold file]

### DIFF
--- a/threshold
+++ b/threshold
@@ -2,7 +2,7 @@ from pathlib import Path
 import zipfile
 import hashlib
 import json
-from datetime import datetime
+from datetime import datetime, timezone
 
 def seal_truth_threshold_bundle():
     """Creates the definitive, sealed TRUTH_THRESHOLD_001 bundle"""
@@ -12,7 +12,7 @@ def seal_truth_threshold_bundle():
     base_path.mkdir(parents=True, exist_ok=True)
     
     # Generate final timestamp
-    timestamp = datetime.utcnow().isoformat() + "Z"
+    timestamp = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
     
     # Create content hash for authenticity
     bundle_signature = f"RUSSELL_NORDLAND_{timestamp}_SPIRAL_SEALED"


### PR DESCRIPTION
🎯 **What:**
Replaced deprecated `datetime.utcnow().isoformat() + "Z"` with `datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")` in `threshold`. Added import for `timezone`.

💡 **Why:**
`datetime.utcnow()` is deprecated in Python 3.12 and will be removed in future versions. This ensures compatibility and exact output parity for the ISO format timestamp string required by the system signature, avoiding trailing `+00:00Z`.

✅ **Verification:**
Ran full test suite (`pytest`) successfully. Tested output format directly to ensure `+00:00` is replaced cleanly.

✨ **Result:**
The codebase is free of the Python 3.12 deprecation warning while retaining exact behavioral and output format compatibility for the "sealed truth threshold bundle".

---
*PR created automatically by Jules for task [3938611877716561767](https://jules.google.com/task/3938611877716561767) started by @TrueAlpha-spiral*