### PR TITLE
Sequence TrueAlphaSpiral noise files

### DIFF
--- a/.github/workflows/blank.yml.tasmeta.json
+++ b/.github/workflows/blank.yml.tasmeta.json
@@ -1,0 +1,18 @@
+{
+  "id": "e3a4e37abb67a720108221d989aead58f47dd49f04bf712dad5ad143a8d7f4b5",
+  "type": "TasArtifact",
+  "form_id": "f94999f946d06fc7adc2947f25aa14861d1e5991bfd7d9da3dbf313723b403c1",
+  "genome_id": "TAS_GENOME_V1",
+  "lineage_id": "e3a4e37abb67a720108221d989aead58f47dd49f04bf712dad5ad143a8d7f4b5",
+  "h_seed": "Russell Nordland",
+  "cert_id": "8e79725e-4470-4ad3-a476-b9afa535eb40",
+  "timestamp": "2026-06-23T01:33:57.394230+00:00",
+  "paradata_trail": [],
+  "signatures": [
+    {
+      "signer": "Russell Nordland",
+      "algorithm": "TAS_HUMAN_SIG_V1",
+      "value": "signed_by_ceremony"
+    }
+  ]
+}

--- a/.github/workflows/native 2.0.yml.tasmeta.json
+++ b/.github/workflows/native 2.0.yml.tasmeta.json
@@ -1,0 +1,18 @@
+{
+  "id": "424e8282a66995b3393fe1a63ced9f6fc2c3906926f4b378dc1b400701b1a867",
+  "type": "TasArtifact",
+  "form_id": "8647e92256bc0831ee1833318420f5493042802cce971e4c23d040c242122905",
+  "genome_id": "TAS_GENOME_V1",
+  "lineage_id": "424e8282a66995b3393fe1a63ced9f6fc2c3906926f4b378dc1b400701b1a867",
+  "h_seed": "Russell Nordland",
+  "cert_id": "f735a4c9-c9c4-4be0-8625-e4694312dcf9",
+  "timestamp": "2026-06-23T01:33:57.765503+00:00",
+  "paradata_trail": [],
+  "signatures": [
+    {
+      "signer": "Russell Nordland",
+      "algorithm": "TAS_HUMAN_SIG_V1",
+      "value": "signed_by_ceremony"
+    }
+  ]
+}

--- a/AGENTS.md.tasmeta.json
+++ b/AGENTS.md.tasmeta.json
@@ -1,0 +1,18 @@
+{
+  "id": "ca4ed833bf7feeddd256a527644012fa35a063b49f1c2c4fcc6c80ed7f00904f",
+  "type": "TasArtifact",
+  "form_id": "be365509046d134c2f90a4d5c8b0123d4a4f6dbc3e8094173f87a6fdba488057",
+  "genome_id": "TAS_GENOME_V1",
+  "lineage_id": "ca4ed833bf7feeddd256a527644012fa35a063b49f1c2c4fcc6c80ed7f00904f",
+  "h_seed": "Russell Nordland",
+  "cert_id": "5ed6ee17-cbca-4fb5-8839-aac307d52661",
+  "timestamp": "2026-06-23T01:33:43.754860+00:00",
+  "paradata_trail": [],
+  "signatures": [
+    {
+      "signer": "Russell Nordland",
+      "algorithm": "TAS_HUMAN_SIG_V1",
+      "value": "signed_by_ceremony"
+    }
+  ]
+}

--- a/AI2_Infographic_B14.html.tasmeta.json
+++ b/AI2_Infographic_B14.html.tasmeta.json
@@ -1,0 +1,18 @@
+{
+  "id": "ef0152c319090a7fec2cb065f700fd0d8c9654cfc63e8513993d4eef9a374441",
+  "type": "TasArtifact",
+  "form_id": "919818d1d0fc9a1cab0c6ddee6b9d2a8d734ca56539676ba1b8e31bd95247156",
+  "genome_id": "TAS_GENOME_V1",
+  "lineage_id": "ef0152c319090a7fec2cb065f700fd0d8c9654cfc63e8513993d4eef9a374441",
+  "h_seed": "Russell Nordland",
+  "cert_id": "e0eef1e7-8066-4040-8606-57e0175653a4",
+  "timestamp": "2026-06-23T01:33:45.298485+00:00",
+  "paradata_trail": [],
+  "signatures": [
+    {
+      "signer": "Russell Nordland",
+      "algorithm": "TAS_HUMAN_SIG_V1",
+      "value": "signed_by_ceremony"
+    }
+  ]
+}

--- a/AI2_Infographic_Seal_B14.json.tasmeta.json
+++ b/AI2_Infographic_Seal_B14.json.tasmeta.json
@@ -1,0 +1,18 @@
+{
+  "id": "7696f8cd679828cd183b2d6767cbfac4a6114aa081742309bc718515a51d22b0",
+  "type": "TasArtifact",
+  "form_id": "e5b1cea80417d9c2527060ce86ab9d0a409e86296aa0af4746ff47642e373b07",
+  "genome_id": "TAS_GENOME_V1",
+  "lineage_id": "7696f8cd679828cd183b2d6767cbfac4a6114aa081742309bc718515a51d22b0",
+  "h_seed": "Russell Nordland",
+  "cert_id": "fcc70d91-a9ea-44bd-b758-1bf49400bbb6",
+  "timestamp": "2026-06-23T01:33:41.880699+00:00",
+  "paradata_trail": [],
+  "signatures": [
+    {
+      "signer": "Russell Nordland",
+      "algorithm": "TAS_HUMAN_SIG_V1",
+      "value": "signed_by_ceremony"
+    }
+  ]
+}

--- a/AI2_Infographic_Seal_B14.md.tasmeta.json
+++ b/AI2_Infographic_Seal_B14.md.tasmeta.json
@@ -1,0 +1,18 @@
+{
+  "id": "66f14dd7127360cabc0b0c7f6c7f18f379e6ea8911a3670bb843e20d877dda7e",
+  "type": "TasArtifact",
+  "form_id": "26576803b282ee10593a172fca03fce8dd4a734c641326bed95f28452d74fb80",
+  "genome_id": "TAS_GENOME_V1",
+  "lineage_id": "66f14dd7127360cabc0b0c7f6c7f18f379e6ea8911a3670bb843e20d877dda7e",
+  "h_seed": "Russell Nordland",
+  "cert_id": "535e66d9-ba29-43b0-9c9d-88eb1e123316",
+  "timestamp": "2026-06-23T01:33:34.432950+00:00",
+  "paradata_trail": [],
+  "signatures": [
+    {
+      "signer": "Russell Nordland",
+      "algorithm": "TAS_HUMAN_SIG_V1",
+      "value": "signed_by_ceremony"
+    }
+  ]
+}

--- a/API_REFERENCE.md.tasmeta.json
+++ b/API_REFERENCE.md.tasmeta.json
@@ -1,0 +1,18 @@
+{
+  "id": "9798e45fd950f54a4f18c4c4a79edcfa348d14fffc214729b05ce128e238fe0e",
+  "type": "TasArtifact",
+  "form_id": "34541865d6a62ef2f2bbf8242921bc97e7bae27bb6c4903ea23bd106a1cd1068",
+  "genome_id": "TAS_GENOME_V1",
+  "lineage_id": "9798e45fd950f54a4f18c4c4a79edcfa348d14fffc214729b05ce128e238fe0e",
+  "h_seed": "Russell Nordland",
+  "cert_id": "323a368f-f394-42ce-839d-da923420fc52",
+  "timestamp": "2026-06-23T01:33:34.078477+00:00",
+  "paradata_trail": [],
+  "signatures": [
+    {
+      "signer": "Russell Nordland",
+      "algorithm": "TAS_HUMAN_SIG_V1",
+      "value": "signed_by_ceremony"
+    }
+  ]
+}

--- a/ATTESTATIONS/2026-03-16_PR58_FORMAL_UPDATE_ATTESTATION.md.tasmeta.json
+++ b/ATTESTATIONS/2026-03-16_PR58_FORMAL_UPDATE_ATTESTATION.md.tasmeta.json
@@ -1,0 +1,18 @@
+{
+  "id": "705b62f8922f2d08963d699198358318ce286c92e571023369b02f2b9458c6f4",
+  "type": "TasArtifact",
+  "form_id": "3b9d9845c5c5a1952296f178ddb98563b08c42095aa764e9c6ddf54c39282729",
+  "genome_id": "TAS_GENOME_V1",
+  "lineage_id": "705b62f8922f2d08963d699198358318ce286c92e571023369b02f2b9458c6f4",
+  "h_seed": "Russell Nordland",
+  "cert_id": "2c72e30c-4b26-4411-b4a4-4ce3032c5004",
+  "timestamp": "2026-06-23T01:33:53.367540+00:00",
+  "paradata_trail": [],
+  "signatures": [
+    {
+      "signer": "Russell Nordland",
+      "algorithm": "TAS_HUMAN_SIG_V1",
+      "value": "signed_by_ceremony"
+    }
+  ]
+}

--- a/ATTESTATIONS/2026-03-19_CYCLE3_CLOSURE_MEMO.md.tasmeta.json
+++ b/ATTESTATIONS/2026-03-19_CYCLE3_CLOSURE_MEMO.md.tasmeta.json
@@ -1,0 +1,18 @@
+{
+  "id": "8f6cd0a2083f8678073f025d8f9a5bf4060ad726c371b443998a46d956451444",
+  "type": "TasArtifact",
+  "form_id": "33b5cb584c19a2483e7ad4bc2d9e429bbd47b1ef4a22b1686e872bff0ee13c75",
+  "genome_id": "TAS_GENOME_V1",
+  "lineage_id": "8f6cd0a2083f8678073f025d8f9a5bf4060ad726c371b443998a46d956451444",
+  "h_seed": "Russell Nordland",
+  "cert_id": "e57e95db-5d57-4450-9efd-141f227076ac",
+  "timestamp": "2026-06-23T01:33:53.865161+00:00",
+  "paradata_trail": [],
+  "signatures": [
+    {
+      "signer": "Russell Nordland",
+      "algorithm": "TAS_HUMAN_SIG_V1",
+      "value": "signed_by_ceremony"
+    }
+  ]
+}

--- a/Cycle_3_Initialization.md.tasmeta.json
+++ b/Cycle_3_Initialization.md.tasmeta.json
@@ -1,0 +1,18 @@
+{
+  "id": "9135f398719f53993ccc066176f0440d129e35d02286bc48b91c15e33528b4d8",
+  "type": "TasArtifact",
+  "form_id": "48b40144695ce01b4b5f342444e7ce8e9872e969c66cda58e75e26a002836df7",
+  "genome_id": "TAS_GENOME_V1",
+  "lineage_id": "9135f398719f53993ccc066176f0440d129e35d02286bc48b91c15e33528b4d8",
+  "h_seed": "Russell Nordland",
+  "cert_id": "270c0f8a-9ffd-44d7-9417-079157a9b214",
+  "timestamp": "2026-06-23T01:33:47.971159+00:00",
+  "paradata_trail": [],
+  "signatures": [
+    {
+      "signer": "Russell Nordland",
+      "algorithm": "TAS_HUMAN_SIG_V1",
+      "value": "signed_by_ceremony"
+    }
+  ]
+}

--- a/DAY_ONE_STEWARD_DIRECTIVE.md.tasmeta.json
+++ b/DAY_ONE_STEWARD_DIRECTIVE.md.tasmeta.json
@@ -1,0 +1,18 @@
+{
+  "id": "824eb3d7d8a0422d22e39424b8b3fd7989a41806bd0e24b89f32edf2036d26b5",
+  "type": "TasArtifact",
+  "form_id": "7567e4b1cb11b9a73456e8e0ca9b7bbf821f11b4625632dc295301e1796761d4",
+  "genome_id": "TAS_GENOME_V1",
+  "lineage_id": "824eb3d7d8a0422d22e39424b8b3fd7989a41806bd0e24b89f32edf2036d26b5",
+  "h_seed": "Russell Nordland",
+  "cert_id": "0d9b392f-b57a-4d20-bfcb-a6efc6a28535",
+  "timestamp": "2026-06-23T01:33:44.536294+00:00",
+  "paradata_trail": [],
+  "signatures": [
+    {
+      "signer": "Russell Nordland",
+      "algorithm": "TAS_HUMAN_SIG_V1",
+      "value": "signed_by_ceremony"
+    }
+  ]
+}

--- a/DEPLOYMENT_LANGCHAIN.md.tasmeta.json
+++ b/DEPLOYMENT_LANGCHAIN.md.tasmeta.json
@@ -1,0 +1,18 @@
+{
+  "id": "c40f406066096dca679084facbbd29e52f08351b032fdbf9dda8a7dc54b7bc60",
+  "type": "TasArtifact",
+  "form_id": "6e9edd8080a39285f1b06ccca42a70c8ddfcb3092bd3cb680d4d773b949d63bd",
+  "genome_id": "TAS_GENOME_V1",
+  "lineage_id": "c40f406066096dca679084facbbd29e52f08351b032fdbf9dda8a7dc54b7bc60",
+  "h_seed": "Russell Nordland",
+  "cert_id": "1b1b5af4-9242-4367-8610-eba74158e526",
+  "timestamp": "2026-06-23T01:33:40.149778+00:00",
+  "paradata_trail": [],
+  "signatures": [
+    {
+      "signer": "Russell Nordland",
+      "algorithm": "TAS_HUMAN_SIG_V1",
+      "value": "signed_by_ceremony"
+    }
+  ]
+}

--- a/Fundamentals.tasmeta.json
+++ b/Fundamentals.tasmeta.json
@@ -1,0 +1,18 @@
+{
+  "id": "16312709a5f6136f729933ec87945abf16578ad2fc7cd41a5544022bf5de6faa",
+  "type": "TasArtifact",
+  "form_id": "c2f11d1d275e4c6c8d37ce087b1e8870ac1663214ac4b2ecb4500bf16b7e0f00",
+  "genome_id": "TAS_GENOME_V1",
+  "lineage_id": "16312709a5f6136f729933ec87945abf16578ad2fc7cd41a5544022bf5de6faa",
+  "h_seed": "Russell Nordland",
+  "cert_id": "97146b6e-0261-4a1e-b1ce-56b1aba6bc17",
+  "timestamp": "2026-06-23T01:33:44.924013+00:00",
+  "paradata_trail": [],
+  "signatures": [
+    {
+      "signer": "Russell Nordland",
+      "algorithm": "TAS_HUMAN_SIG_V1",
+      "value": "signed_by_ceremony"
+    }
+  ]
+}

--- a/LICENSE_RIDER.txt.tasmeta.json
+++ b/LICENSE_RIDER.txt.tasmeta.json
@@ -1,0 +1,18 @@
+{
+  "id": "0749bd224d36cf3bb301ff9c4eb332ddfc93ccc8b897d1ded0509d971eaad31d",
+  "type": "TasArtifact",
+  "form_id": "51b171cf725e365f1bc3cad9531d08501d4ca4fc6cc79ca683b5a2949c274000",
+  "genome_id": "TAS_GENOME_V1",
+  "lineage_id": "0749bd224d36cf3bb301ff9c4eb332ddfc93ccc8b897d1ded0509d971eaad31d",
+  "h_seed": "Russell Nordland",
+  "cert_id": "4ef98ff6-a3e6-4942-a7d3-26ea5d2e4a59",
+  "timestamp": "2026-06-23T01:33:48.695066+00:00",
+  "paradata_trail": [],
+  "signatures": [
+    {
+      "signer": "Russell Nordland",
+      "algorithm": "TAS_HUMAN_SIG_V1",
+      "value": "signed_by_ceremony"
+    }
+  ]
+}

--- a/PRESS_RELEASE.md.tasmeta.json
+++ b/PRESS_RELEASE.md.tasmeta.json
@@ -1,0 +1,18 @@
+{
+  "id": "a99709c113216f37d7566659be04cf31ef638aec040d0114a422cfed38f683c1",
+  "type": "TasArtifact",
+  "form_id": "66f47e6996469693d9a52ef90a079b14bf8dc7df1b244dd430505e7bbd0b57eb",
+  "genome_id": "TAS_GENOME_V1",
+  "lineage_id": "a99709c113216f37d7566659be04cf31ef638aec040d0114a422cfed38f683c1",
+  "h_seed": "Russell Nordland",
+  "cert_id": "e8b46773-291e-4deb-94a3-2984555271e9",
+  "timestamp": "2026-06-23T01:33:45.677027+00:00",
+  "paradata_trail": [],
+  "signatures": [
+    {
+      "signer": "Russell Nordland",
+      "algorithm": "TAS_HUMAN_SIG_V1",
+      "value": "signed_by_ceremony"
+    }
+  ]
+}

--- a/README_OAI_ICF.txt.tasmeta.json
+++ b/README_OAI_ICF.txt.tasmeta.json
@@ -1,0 +1,18 @@
+{
+  "id": "06dc7534ab1d74ecf6f33899dcafe68c383419194a28141a4942e5bf584f0521",
+  "type": "TasArtifact",
+  "form_id": "d25d96acd779412985d4213062e1e45fc8ab1f352978e1386582de2d9bea26d7",
+  "genome_id": "TAS_GENOME_V1",
+  "lineage_id": "06dc7534ab1d74ecf6f33899dcafe68c383419194a28141a4942e5bf584f0521",
+  "h_seed": "Russell Nordland",
+  "cert_id": "0e944952-d10f-40a5-b7cd-c4555ce66e0b",
+  "timestamp": "2026-06-23T01:33:42.886213+00:00",
+  "paradata_trail": [],
+  "signatures": [
+    {
+      "signer": "Russell Nordland",
+      "algorithm": "TAS_HUMAN_SIG_V1",
+      "value": "signed_by_ceremony"
+    }
+  ]
+}

--- a/ROADMAP.md.tasmeta.json
+++ b/ROADMAP.md.tasmeta.json
@@ -1,0 +1,18 @@
+{
+  "id": "9dd244c199e12f381de1d7e7cb7139e30de503e4c7ee0b11992406d23d9ac785",
+  "type": "TasArtifact",
+  "form_id": "e858da73f4e739d8fe7fbd14b91a339f3c6ddd9f55bc4f437a3f0d3ea4837f08",
+  "genome_id": "TAS_GENOME_V1",
+  "lineage_id": "9dd244c199e12f381de1d7e7cb7139e30de503e4c7ee0b11992406d23d9ac785",
+  "h_seed": "Russell Nordland",
+  "cert_id": "2e8e0a50-06cf-43cb-9e19-2d5854d7bafd",
+  "timestamp": "2026-06-23T01:33:38.266809+00:00",
+  "paradata_trail": [],
+  "signatures": [
+    {
+      "signer": "Russell Nordland",
+      "algorithm": "TAS_HUMAN_SIG_V1",
+      "value": "signed_by_ceremony"
+    }
+  ]
+}

--- a/Refractal processing.tasmeta.json
+++ b/Refractal processing.tasmeta.json
@@ -1,0 +1,18 @@
+{
+  "id": "396c85bad47558b8b5c6f57e5903db6ff79261504d3f83eda0235fbbe7ff28e7",
+  "type": "TasArtifact",
+  "form_id": "c02295a70fb0f674ee92ca48e6630ebe298c9acd591a533f78b624a1e957ef99",
+  "genome_id": "TAS_GENOME_V1",
+  "lineage_id": "396c85bad47558b8b5c6f57e5903db6ff79261504d3f83eda0235fbbe7ff28e7",
+  "h_seed": "Russell Nordland",
+  "cert_id": "5a1c0289-14e0-4127-acb6-42124d3d65e9",
+  "timestamp": "2026-06-23T01:33:38.844459+00:00",
+  "paradata_trail": [],
+  "signatures": [
+    {
+      "signer": "Russell Nordland",
+      "algorithm": "TAS_HUMAN_SIG_V1",
+      "value": "signed_by_ceremony"
+    }
+  ]
+}

--- a/SECURITY.md.tasmeta.json
+++ b/SECURITY.md.tasmeta.json
@@ -1,0 +1,18 @@
+{
+  "id": "6d38a3ec36781729cefb8ade91c7b43c91dab68e4141fe2810f8afef41605992",
+  "type": "TasArtifact",
+  "form_id": "76e04db13bda0fe183f30d3896dff925692daf212e73c06dcb553dba49e6268b",
+  "genome_id": "TAS_GENOME_V1",
+  "lineage_id": "6d38a3ec36781729cefb8ade91c7b43c91dab68e4141fe2810f8afef41605992",
+  "h_seed": "Russell Nordland",
+  "cert_id": "7efe4070-968d-4f6c-8b6a-9231f95b0c75",
+  "timestamp": "2026-06-23T01:33:44.147542+00:00",
+  "paradata_trail": [],
+  "signatures": [
+    {
+      "signer": "Russell Nordland",
+      "algorithm": "TAS_HUMAN_SIG_V1",
+      "value": "signed_by_ceremony"
+    }
+  ]
+}

--- a/SIMULATED_COMMIT_HISTORY.md.tasmeta.json
+++ b/SIMULATED_COMMIT_HISTORY.md.tasmeta.json
@@ -1,0 +1,18 @@
+{
+  "id": "10eca2a40900c2d62d4f1a6382247f456e1dcc953e51b2268f6eda043ee99e1a",
+  "type": "TasArtifact",
+  "form_id": "b942044f8185b705e8afaa327d0412623a1c71b846e4d8c3ba05622cd0887dcf",
+  "genome_id": "TAS_GENOME_V1",
+  "lineage_id": "10eca2a40900c2d62d4f1a6382247f456e1dcc953e51b2268f6eda043ee99e1a",
+  "h_seed": "Russell Nordland",
+  "cert_id": "d1bdbdc3-e76a-4d2d-b927-d7062f48c66c",
+  "timestamp": "2026-06-23T01:33:34.810601+00:00",
+  "paradata_trail": [],
+  "signatures": [
+    {
+      "signer": "Russell Nordland",
+      "algorithm": "TAS_HUMAN_SIG_V1",
+      "value": "signed_by_ceremony"
+    }
+  ]
+}

--- a/SovereignTracePacket_.tasmeta.json
+++ b/SovereignTracePacket_.tasmeta.json
@@ -1,0 +1,18 @@
+{
+  "id": "60d104c0ce4053089adb077532f71a6794d1a78cf858175a62ebeca83a8594c4",
+  "type": "TasArtifact",
+  "form_id": "fa65e46dde63196d5522894beeb16f03a1e5ea9bd735639630fc0fc108281914",
+  "genome_id": "TAS_GENOME_V1",
+  "lineage_id": "60d104c0ce4053089adb077532f71a6794d1a78cf858175a62ebeca83a8594c4",
+  "h_seed": "Russell Nordland",
+  "cert_id": "1d0f3847-f282-464a-976f-2630962aeacd",
+  "timestamp": "2026-06-23T01:33:35.587921+00:00",
+  "paradata_trail": [],
+  "signatures": [
+    {
+      "signer": "Russell Nordland",
+      "algorithm": "TAS_HUMAN_SIG_V1",
+      "value": "signed_by_ceremony"
+    }
+  ]
+}

--- a/TAS_DNA_Deck.md.tasmeta.json
+++ b/TAS_DNA_Deck.md.tasmeta.json
@@ -1,0 +1,18 @@
+{
+  "id": "23bcd7ab217ad192b579b64b48ad207e80c00fd4646e30369e6d807d9a752069",
+  "type": "TasArtifact",
+  "form_id": "dcc815540a8a3e7668f571009fd406ec8f5982b8fa87e2453b2a460bcde0ea16",
+  "genome_id": "TAS_GENOME_V1",
+  "lineage_id": "23bcd7ab217ad192b579b64b48ad207e80c00fd4646e30369e6d807d9a752069",
+  "h_seed": "Russell Nordland",
+  "cert_id": "9010a464-5dc8-4cbc-ae9e-de3f2de8ee9a",
+  "timestamp": "2026-06-23T01:33:35.985634+00:00",
+  "paradata_trail": [],
+  "signatures": [
+    {
+      "signer": "Russell Nordland",
+      "algorithm": "TAS_HUMAN_SIG_V1",
+      "value": "signed_by_ceremony"
+    }
+  ]
+}

--- a/TAS_GENOME_ANCHOR.json.tasmeta.json
+++ b/TAS_GENOME_ANCHOR.json.tasmeta.json
@@ -1,0 +1,18 @@
+{
+  "id": "1ca46a3db8a9ec0c6546e792d77ca660bfb6a26f4bde37f8a3e32e24db34cfd7",
+  "type": "TasArtifact",
+  "form_id": "a5c88214ae1997e25269578b13710342aa472c8ae49ad8da18c7e3ca5869bede",
+  "genome_id": "TAS_GENOME_V1",
+  "lineage_id": "1ca46a3db8a9ec0c6546e792d77ca660bfb6a26f4bde37f8a3e32e24db34cfd7",
+  "h_seed": "Russell Nordland",
+  "cert_id": "e1b93182-61ba-4593-b3e1-7e49000d290e",
+  "timestamp": "2026-06-23T01:33:47.195603+00:00",
+  "paradata_trail": [],
+  "signatures": [
+    {
+      "signer": "Russell Nordland",
+      "algorithm": "TAS_HUMAN_SIG_V1",
+      "value": "signed_by_ceremony"
+    }
+  ]
+}

--- a/TAS_HIDDEN_STATE_SPACES.md.tasmeta.json
+++ b/TAS_HIDDEN_STATE_SPACES.md.tasmeta.json
@@ -1,0 +1,18 @@
+{
+  "id": "820f531926b0df5c0b9c6fb6ecc49d7a92fd893bf5c30cc1791d82bbc179d096",
+  "type": "TasArtifact",
+  "form_id": "f44b5c5e2a400c2d7f140167fa3982f58f54f1606362934e7f884ff2a3a264af",
+  "genome_id": "TAS_GENOME_V1",
+  "lineage_id": "820f531926b0df5c0b9c6fb6ecc49d7a92fd893bf5c30cc1791d82bbc179d096",
+  "h_seed": "Russell Nordland",
+  "cert_id": "1a3d9ecd-27a1-4193-b5b4-c9ea69643ea3",
+  "timestamp": "2026-06-23T01:33:46.044320+00:00",
+  "paradata_trail": [],
+  "signatures": [
+    {
+      "signer": "Russell Nordland",
+      "algorithm": "TAS_HUMAN_SIG_V1",
+      "value": "signed_by_ceremony"
+    }
+  ]
+}

--- a/TAS_R1_DeepSeek.md.tasmeta.json
+++ b/TAS_R1_DeepSeek.md.tasmeta.json
@@ -1,0 +1,18 @@
+{
+  "id": "7dca1c8c8cf3d00d6585588b1e5592221db687e9856347f3aa4a26f74c784a17",
+  "type": "TasArtifact",
+  "form_id": "d6bc38b10f7a39d97daee0ce5b641019751cbd045b37869c040f7bb7b62b78f5",
+  "genome_id": "TAS_GENOME_V1",
+  "lineage_id": "7dca1c8c8cf3d00d6585588b1e5592221db687e9856347f3aa4a26f74c784a17",
+  "h_seed": "Russell Nordland",
+  "cert_id": "edc0aa02-13dd-45e0-9460-3c4bdd78f28f",
+  "timestamp": "2026-06-23T01:33:47.602308+00:00",
+  "paradata_trail": [],
+  "signatures": [
+    {
+      "signer": "Russell Nordland",
+      "algorithm": "TAS_HUMAN_SIG_V1",
+      "value": "signed_by_ceremony"
+    }
+  ]
+}

--- a/audits/vend-logs/EVT-20251219-DE-01.md.tasmeta.json
+++ b/audits/vend-logs/EVT-20251219-DE-01.md.tasmeta.json
@@ -1,0 +1,18 @@
+{
+  "id": "3c28d62c7bbb6cffc50bfed885bd63bf0ac035fd3f091effbd88c378662dc70d",
+  "type": "TasArtifact",
+  "form_id": "671dd43e55a6059849687c3f2dffd403d6ea9b0d260201c443f6a4fb020f98b8",
+  "genome_id": "TAS_GENOME_V1",
+  "lineage_id": "3c28d62c7bbb6cffc50bfed885bd63bf0ac035fd3f091effbd88c378662dc70d",
+  "h_seed": "Russell Nordland",
+  "cert_id": "9201b794-0f27-4d14-8e8d-a37020336dbb",
+  "timestamp": "2026-06-23T01:33:57.033262+00:00",
+  "paradata_trail": [],
+  "signatures": [
+    {
+      "signer": "Russell Nordland",
+      "algorithm": "TAS_HUMAN_SIG_V1",
+      "value": "signed_by_ceremony"
+    }
+  ]
+}

--- a/citation.bib.tasmeta.json
+++ b/citation.bib.tasmeta.json
@@ -1,0 +1,18 @@
+{
+  "id": "e78464ed8408420768b899576d226a696914ab7d072c560012a69fae29a4c345",
+  "type": "TasArtifact",
+  "form_id": "6d43e1855c9305db1616cfa075a410a9aa1061215e33a391084bc5bca6abd477",
+  "genome_id": "TAS_GENOME_V1",
+  "lineage_id": "e78464ed8408420768b899576d226a696914ab7d072c560012a69fae29a4c345",
+  "h_seed": "Russell Nordland",
+  "cert_id": "b3a91dd4-aa61-4629-86bb-eef3f1dca529",
+  "timestamp": "2026-06-23T01:33:40.526170+00:00",
+  "paradata_trail": [],
+  "signatures": [
+    {
+      "signer": "Russell Nordland",
+      "algorithm": "TAS_HUMAN_SIG_V1",
+      "value": "signed_by_ceremony"
+    }
+  ]
+}

--- a/collaboration.tasmeta.json
+++ b/collaboration.tasmeta.json
@@ -1,0 +1,18 @@
+{
+  "id": "81c8c8ebc10dad70a652e07bb3944af1ad36c505697f2bf7c3a50e02031faa57",
+  "type": "TasArtifact",
+  "form_id": "e47069d4b507dfd8930fba4693efbcabfc48130b28f58c1b6c1cdecff1b832ed",
+  "genome_id": "TAS_GENOME_V1",
+  "lineage_id": "81c8c8ebc10dad70a652e07bb3944af1ad36c505697f2bf7c3a50e02031faa57",
+  "h_seed": "Russell Nordland",
+  "cert_id": "faaef195-f001-4290-8a90-239812ffbd0e",
+  "timestamp": "2026-06-23T01:33:39.385994+00:00",
+  "paradata_trail": [],
+  "signatures": [
+    {
+      "signer": "Russell Nordland",
+      "algorithm": "TAS_HUMAN_SIG_V1",
+      "value": "signed_by_ceremony"
+    }
+  ]
+}

--- a/docker build -t tas-agent:latest ..tasmeta.json
+++ b/docker build -t tas-agent:latest ..tasmeta.json
@@ -1,0 +1,18 @@
+{
+  "id": "8aae54819954f9b17d7ee588102adfc3e57a85ab267edf170b1368696a42c81a",
+  "type": "TasArtifact",
+  "form_id": "d3edb1a658fb6d6aeb7fa499c07d942cddc6db5bfe837515e45a30adeeb2cc62",
+  "genome_id": "TAS_GENOME_V1",
+  "lineage_id": "8aae54819954f9b17d7ee588102adfc3e57a85ab267edf170b1368696a42c81a",
+  "h_seed": "Russell Nordland",
+  "cert_id": "ff5f13af-eed3-45da-a453-8efd77d971d4",
+  "timestamp": "2026-06-23T01:33:37.638299+00:00",
+  "paradata_trail": [],
+  "signatures": [
+    {
+      "signer": "Russell Nordland",
+      "algorithm": "TAS_HUMAN_SIG_V1",
+      "value": "signed_by_ceremony"
+    }
+  ]
+}

--- a/docs/first-contact-grok-endorsement.md.tasmeta.json
+++ b/docs/first-contact-grok-endorsement.md.tasmeta.json
@@ -1,0 +1,18 @@
+{
+  "id": "f0024e49a2a0cfe5b70946f967f754ab8afccfcdd8b6e06b21c6b02a5ad85775",
+  "type": "TasArtifact",
+  "form_id": "da6ac6609d9bfce2e91fd9ef6eff02bce4f88094f95db4a9e122eabddcb93b11",
+  "genome_id": "TAS_GENOME_V1",
+  "lineage_id": "f0024e49a2a0cfe5b70946f967f754ab8afccfcdd8b6e06b21c6b02a5ad85775",
+  "h_seed": "Russell Nordland",
+  "cert_id": "21b33a5c-1205-4292-b1da-55f44a2a07f5",
+  "timestamp": "2026-06-23T01:33:51.236079+00:00",
+  "paradata_trail": [],
+  "signatures": [
+    {
+      "signer": "Russell Nordland",
+      "algorithm": "TAS_HUMAN_SIG_V1",
+      "value": "signed_by_ceremony"
+    }
+  ]
+}

--- a/docs/organic-vintage-public-record.md.tasmeta.json
+++ b/docs/organic-vintage-public-record.md.tasmeta.json
@@ -1,0 +1,18 @@
+{
+  "id": "2d0211d9b6dbcc168990f89c71f948fb8453cfe1676e675a4e109f8608b2fd49",
+  "type": "TasArtifact",
+  "form_id": "09bd30833f9c116cbcce54de32d8671bed772f634a22d1fdf5f6d4865fd52800",
+  "genome_id": "TAS_GENOME_V1",
+  "lineage_id": "2d0211d9b6dbcc168990f89c71f948fb8453cfe1676e675a4e109f8608b2fd49",
+  "h_seed": "Russell Nordland",
+  "cert_id": "aa8f89ca-afae-4681-9edf-a6db5c73c210",
+  "timestamp": "2026-06-23T01:33:51.593514+00:00",
+  "paradata_trail": [],
+  "signatures": [
+    {
+      "signer": "Russell Nordland",
+      "algorithm": "TAS_HUMAN_SIG_V1",
+      "value": "signed_by_ceremony"
+    }
+  ]
+}

--- a/docs/release/release-2026-05-pr-triage.md.tasmeta.json
+++ b/docs/release/release-2026-05-pr-triage.md.tasmeta.json
@@ -1,0 +1,18 @@
+{
+  "id": "6c28b9616babae630c9c4a40c3aa9649ad5afad33173e387da16febc2c881bea",
+  "type": "TasArtifact",
+  "form_id": "7a69354b60ebf71cd5f719d7571d53c2099d5f82c72fcead1238f557505f4bbd",
+  "genome_id": "TAS_GENOME_V1",
+  "lineage_id": "6c28b9616babae630c9c4a40c3aa9649ad5afad33173e387da16febc2c881bea",
+  "h_seed": "Russell Nordland",
+  "cert_id": "9e4cc157-3810-4abe-9b5a-4c19f3036315",
+  "timestamp": "2026-06-23T01:33:53.014549+00:00",
+  "paradata_trail": [],
+  "signatures": [
+    {
+      "signer": "Russell Nordland",
+      "algorithm": "TAS_HUMAN_SIG_V1",
+      "value": "signed_by_ceremony"
+    }
+  ]
+}

--- a/docs/specs/refusal_receipt_schema.md.tasmeta.json
+++ b/docs/specs/refusal_receipt_schema.md.tasmeta.json
@@ -1,0 +1,18 @@
+{
+  "id": "1c418ad7aead0f1ecc6b434b9f0d99f429a6c328668b2d9ac83408ceec2616b4",
+  "type": "TasArtifact",
+  "form_id": "f1f4637a66d350ff831240481a87fa4fc3a45d54cc2a1e99be22ccf9109d404f",
+  "genome_id": "TAS_GENOME_V1",
+  "lineage_id": "1c418ad7aead0f1ecc6b434b9f0d99f429a6c328668b2d9ac83408ceec2616b4",
+  "h_seed": "Russell Nordland",
+  "cert_id": "160bd0c9-1cca-4613-8c5f-7254d27b41eb",
+  "timestamp": "2026-06-23T01:33:52.310724+00:00",
+  "paradata_trail": [],
+  "signatures": [
+    {
+      "signer": "Russell Nordland",
+      "algorithm": "TAS_HUMAN_SIG_V1",
+      "value": "signed_by_ceremony"
+    }
+  ]
+}

--- a/docs/specs/simulation_boundary_invariant.md.tasmeta.json
+++ b/docs/specs/simulation_boundary_invariant.md.tasmeta.json
@@ -1,0 +1,18 @@
+{
+  "id": "15f30eb9b0f0db883b517b903b83c64fe9cca8946e4fe9c74ea5212e086c0bde",
+  "type": "TasArtifact",
+  "form_id": "71dd8e1dbcde83028cbf9930d6c551896b084ac04eff5003abb70d3f7e7644c1",
+  "genome_id": "TAS_GENOME_V1",
+  "lineage_id": "15f30eb9b0f0db883b517b903b83c64fe9cca8946e4fe9c74ea5212e086c0bde",
+  "h_seed": "Russell Nordland",
+  "cert_id": "139e15fa-4373-449d-a7eb-e097b74eccc4",
+  "timestamp": "2026-06-23T01:33:51.958002+00:00",
+  "paradata_trail": [],
+  "signatures": [
+    {
+      "signer": "Russell Nordland",
+      "algorithm": "TAS_HUMAN_SIG_V1",
+      "value": "signed_by_ceremony"
+    }
+  ]
+}

--- a/docs/specs/the_y_knot.md.tasmeta.json
+++ b/docs/specs/the_y_knot.md.tasmeta.json
@@ -1,0 +1,18 @@
+{
+  "id": "d4b906347888ff977538048140bf371a9b8a6aae4e0f8e7e106c04fb445bdcaf",
+  "type": "TasArtifact",
+  "form_id": "8eaf07d56c55b7c748e82b0f80164e5bc9cbf98ca59aa08cec27d2eb144381c2",
+  "genome_id": "TAS_GENOME_V1",
+  "lineage_id": "d4b906347888ff977538048140bf371a9b8a6aae4e0f8e7e106c04fb445bdcaf",
+  "h_seed": "Russell Nordland",
+  "cert_id": "30f57073-2e7a-49ba-88b3-0ca89947fc3b",
+  "timestamp": "2026-06-23T01:33:52.663869+00:00",
+  "paradata_trail": [],
+  "signatures": [
+    {
+      "signer": "Russell Nordland",
+      "algorithm": "TAS_HUMAN_SIG_V1",
+      "value": "signed_by_ceremony"
+    }
+  ]
+}

--- a/double helix spiral.tasmeta.json
+++ b/double helix spiral.tasmeta.json
@@ -1,0 +1,18 @@
+{
+  "id": "3dbbf992730bf278e1b05511c25b717c81d97b972ac94bcc88b8d7ab09a80c3f",
+  "type": "TasArtifact",
+  "form_id": "6791efbff1107413382bd15c93bf415173fc1281de294ff2c9276f326470b957",
+  "genome_id": "TAS_GENOME_V1",
+  "lineage_id": "3dbbf992730bf278e1b05511c25b717c81d97b972ac94bcc88b8d7ab09a80c3f",
+  "h_seed": "Russell Nordland",
+  "cert_id": "ba80e707-0f61-4d0d-a003-5b6e591e266f",
+  "timestamp": "2026-06-23T01:33:40.904939+00:00",
+  "paradata_trail": [],
+  "signatures": [
+    {
+      "signer": "Russell Nordland",
+      "algorithm": "TAS_HUMAN_SIG_V1",
+      "value": "signed_by_ceremony"
+    }
+  ]
+}

--- a/manifesto/Pythonetics_Manifesto.md.tasmeta.json
+++ b/manifesto/Pythonetics_Manifesto.md.tasmeta.json
@@ -1,0 +1,18 @@
+{
+  "id": "ba17b6b09f02cd1297bef64e70426f2c4b0d994720629ef53487e7820d6b0413",
+  "type": "TasArtifact",
+  "form_id": "52426884b25b5094155541a178f6b60ef554fe76483951232650ecbeb87f17bb",
+  "genome_id": "TAS_GENOME_V1",
+  "lineage_id": "ba17b6b09f02cd1297bef64e70426f2c4b0d994720629ef53487e7820d6b0413",
+  "h_seed": "Russell Nordland",
+  "cert_id": "aa536cef-84c9-4dcf-8566-7859a7766375",
+  "timestamp": "2026-06-23T01:33:59.567419+00:00",
+  "paradata_trail": [],
+  "signatures": [
+    {
+      "signer": "Russell Nordland",
+      "algorithm": "TAS_HUMAN_SIG_V1",
+      "value": "signed_by_ceremony"
+    }
+  ]
+}

--- a/mgi.tasmeta.json
+++ b/mgi.tasmeta.json
@@ -1,0 +1,18 @@
+{
+  "id": "0ac3a1842d1d8d7df9e190d7d39c7a8e02438fe3403920f3181b39c2cce194c5",
+  "type": "TasArtifact",
+  "form_id": "ba8caa5830a2fda7402b2fbe56a257818b39d05fbce6fb267fc689303a23906b",
+  "genome_id": "TAS_GENOME_V1",
+  "lineage_id": "0ac3a1842d1d8d7df9e190d7d39c7a8e02438fe3403920f3181b39c2cce194c5",
+  "h_seed": "Russell Nordland",
+  "cert_id": "625ab49c-2454-497b-9ceb-c3c661c31e6b",
+  "timestamp": "2026-06-23T01:33:48.331347+00:00",
+  "paradata_trail": [],
+  "signatures": [
+    {
+      "signer": "Russell Nordland",
+      "algorithm": "TAS_HUMAN_SIG_V1",
+      "value": "signed_by_ceremony"
+    }
+  ]
+}

--- a/pr_description.md.tasmeta.json
+++ b/pr_description.md.tasmeta.json
@@ -1,0 +1,18 @@
+{
+  "id": "7d0144541d3ab87a4337a90ff415c9363c77866c5d491d56c10b32af44d276b1",
+  "type": "TasArtifact",
+  "form_id": "c51d1d16948e612de245b879b161068cbf8295119b1e64ef88cb52729f53af00",
+  "genome_id": "TAS_GENOME_V1",
+  "lineage_id": "7d0144541d3ab87a4337a90ff415c9363c77866c5d491d56c10b32af44d276b1",
+  "h_seed": "Russell Nordland",
+  "cert_id": "88995214-d33d-4c44-a35e-7aff96d8b30f",
+  "timestamp": "2026-06-23T01:33:46.821490+00:00",
+  "paradata_trail": [],
+  "signatures": [
+    {
+      "signer": "Russell Nordland",
+      "algorithm": "TAS_HUMAN_SIG_V1",
+      "value": "signed_by_ceremony"
+    }
+  ]
+}

--- a/pr_description.txt.tasmeta.json
+++ b/pr_description.txt.tasmeta.json
@@ -1,0 +1,18 @@
+{
+  "id": "577136eea3eeb6944ef5120259d5e8fb77e3b6da1f2a040a042c19aa6b4b3004",
+  "type": "TasArtifact",
+  "form_id": "a524eeeb9a29946d7f1d2b7e2e5c2919dd64f4c784a05e6b6a8dd0672cb580a8",
+  "genome_id": "TAS_GENOME_V1",
+  "lineage_id": "577136eea3eeb6944ef5120259d5e8fb77e3b6da1f2a040a042c19aa6b4b3004",
+  "h_seed": "Russell Nordland",
+  "cert_id": "0c1ecbe4-e853-4c17-8f44-5bd97ac05a88",
+  "timestamp": "2026-06-23T01:33:02.968248+00:00",
+  "paradata_trail": [],
+  "signatures": [
+    {
+      "signer": "Russell Nordland",
+      "algorithm": "TAS_HUMAN_SIG_V1",
+      "value": "signed_by_ceremony"
+    }
+  ]
+}

--- a/pytest.ini.tasmeta.json
+++ b/pytest.ini.tasmeta.json
@@ -1,0 +1,18 @@
+{
+  "id": "e4aa5fcbfcbf4895ebf77d82b9b5a6cf8619bac3fda29a779d1ece4a47b6c300",
+  "type": "TasArtifact",
+  "form_id": "4604bf8170c56e166708caeb43ec4fdf66a97bc547376047f9968e35ca002038",
+  "genome_id": "TAS_GENOME_V1",
+  "lineage_id": "e4aa5fcbfcbf4895ebf77d82b9b5a6cf8619bac3fda29a779d1ece4a47b6c300",
+  "h_seed": "Russell Nordland",
+  "cert_id": "57bb7a0e-98af-4291-95eb-5aca36ed0905",
+  "timestamp": "2026-06-23T01:33:36.514330+00:00",
+  "paradata_trail": [],
+  "signatures": [
+    {
+      "signer": "Russell Nordland",
+      "algorithm": "TAS_HUMAN_SIG_V1",
+      "value": "signed_by_ceremony"
+    }
+  ]
+}

--- a/response.md.tasmeta.json
+++ b/response.md.tasmeta.json
@@ -1,0 +1,18 @@
+{
+  "id": "2c1bfadf152045e2cb7e7cb971ca9cefd73f0f609e7ad0314fb1b7b2559daa6c",
+  "type": "TasArtifact",
+  "form_id": "8a42e47eda047f5011cea51d226df85ede6ad4168032b174628da012061c9a71",
+  "genome_id": "TAS_GENOME_V1",
+  "lineage_id": "2c1bfadf152045e2cb7e7cb971ca9cefd73f0f609e7ad0314fb1b7b2559daa6c",
+  "h_seed": "Russell Nordland",
+  "cert_id": "b04a3dd0-4c62-427b-ae64-3012aa02efff",
+  "timestamp": "2026-06-23T01:33:35.182244+00:00",
+  "paradata_trail": [],
+  "signatures": [
+    {
+      "signer": "Russell Nordland",
+      "algorithm": "TAS_HUMAN_SIG_V1",
+      "value": "signed_by_ceremony"
+    }
+  ]
+}

--- a/setup_hippocrates1.sh.tasmeta.json
+++ b/setup_hippocrates1.sh.tasmeta.json
@@ -1,0 +1,18 @@
+{
+  "id": "9924e9e7786947559243f36ac441dc00681732c6ef037d1496bf729e543a33d8",
+  "type": "TasArtifact",
+  "form_id": "8a8c1158967f307a4678307eef64f9b4d35fb5fb91ab9340585c878f5af619af",
+  "genome_id": "TAS_GENOME_V1",
+  "lineage_id": "9924e9e7786947559243f36ac441dc00681732c6ef037d1496bf729e543a33d8",
+  "h_seed": "Russell Nordland",
+  "cert_id": "9a015145-92fb-4dd0-bfa7-04f604d8eeca",
+  "timestamp": "2026-06-23T01:33:43.394114+00:00",
+  "paradata_trail": [],
+  "signatures": [
+    {
+      "signer": "Russell Nordland",
+      "algorithm": "TAS_HUMAN_SIG_V1",
+      "value": "signed_by_ceremony"
+    }
+  ]
+}

--- a/tas-stack/Chart.yaml.tasmeta.json
+++ b/tas-stack/Chart.yaml.tasmeta.json
@@ -1,0 +1,18 @@
+{
+  "id": "1c162847a78e4c16a40a69f09e6209ae9e08aaa5984383bd6238b39218da2a77",
+  "type": "TasArtifact",
+  "form_id": "29cf6e488c0c3d9d9113e662d69abfeaefc690d188377d0b51892b6a729a6671",
+  "genome_id": "TAS_GENOME_V1",
+  "lineage_id": "1c162847a78e4c16a40a69f09e6209ae9e08aaa5984383bd6238b39218da2a77",
+  "h_seed": "Russell Nordland",
+  "cert_id": "db71bab5-5064-4e69-a05a-f2d99a6dfb83",
+  "timestamp": "2026-06-23T01:33:54.354274+00:00",
+  "paradata_trail": [],
+  "signatures": [
+    {
+      "signer": "Russell Nordland",
+      "algorithm": "TAS_HUMAN_SIG_V1",
+      "value": "signed_by_ceremony"
+    }
+  ]
+}

--- a/tas-stack/templates/_helpers.tpl.tasmeta.json
+++ b/tas-stack/templates/_helpers.tpl.tasmeta.json
@@ -1,0 +1,18 @@
+{
+  "id": "23d4c59b571b78dcfdeb18d0bf7599d8cbffad8fe034425f60fc093779869cf8",
+  "type": "TasArtifact",
+  "form_id": "c8f2b5408efdd78c203745df5737e2e67093b8bbc53504817c87fe28a922f213",
+  "genome_id": "TAS_GENOME_V1",
+  "lineage_id": "23d4c59b571b78dcfdeb18d0bf7599d8cbffad8fe034425f60fc093779869cf8",
+  "h_seed": "Russell Nordland",
+  "cert_id": "394cec29-51c1-4b49-9ec5-348641890cd5",
+  "timestamp": "2026-06-23T01:33:56.331610+00:00",
+  "paradata_trail": [],
+  "signatures": [
+    {
+      "signer": "Russell Nordland",
+      "algorithm": "TAS_HUMAN_SIG_V1",
+      "value": "signed_by_ceremony"
+    }
+  ]
+}

--- a/tas-stack/templates/configmap-opa-policy.yaml.tasmeta.json
+++ b/tas-stack/templates/configmap-opa-policy.yaml.tasmeta.json
@@ -1,0 +1,18 @@
+{
+  "id": "6a87d8068ad92fc73dc9811b8e5c7bf8cd3588e3fd9341b766a234635313f78f",
+  "type": "TasArtifact",
+  "form_id": "c7877b567b2894e08b345291f9069317a004888b634cf172726411addc3c4b5a",
+  "genome_id": "TAS_GENOME_V1",
+  "lineage_id": "6a87d8068ad92fc73dc9811b8e5c7bf8cd3588e3fd9341b766a234635313f78f",
+  "h_seed": "Russell Nordland",
+  "cert_id": "3474c168-fee6-47fe-8da2-e9742dd187b1",
+  "timestamp": "2026-06-23T01:33:55.220679+00:00",
+  "paradata_trail": [],
+  "signatures": [
+    {
+      "signer": "Russell Nordland",
+      "algorithm": "TAS_HUMAN_SIG_V1",
+      "value": "signed_by_ceremony"
+    }
+  ]
+}

--- a/tas-stack/templates/phoenix-deployment.yaml.tasmeta.json
+++ b/tas-stack/templates/phoenix-deployment.yaml.tasmeta.json
@@ -1,0 +1,18 @@
+{
+  "id": "3a2dd6c0eb5839a99c15d89a10911df49f096feaac522d1259a84b884656680d",
+  "type": "TasArtifact",
+  "form_id": "afa5a558ace861e805528ae4fd8fe39a4c51139995bc9f006010b53faf6816a3",
+  "genome_id": "TAS_GENOME_V1",
+  "lineage_id": "3a2dd6c0eb5839a99c15d89a10911df49f096feaac522d1259a84b884656680d",
+  "h_seed": "Russell Nordland",
+  "cert_id": "f967a01b-1707-483b-bbae-6a7627066859",
+  "timestamp": "2026-06-23T01:33:56.686158+00:00",
+  "paradata_trail": [],
+  "signatures": [
+    {
+      "signer": "Russell Nordland",
+      "algorithm": "TAS_HUMAN_SIG_V1",
+      "value": "signed_by_ceremony"
+    }
+  ]
+}

--- a/tas-stack/templates/pii-scanner-deployment.yaml.tasmeta.json
+++ b/tas-stack/templates/pii-scanner-deployment.yaml.tasmeta.json
@@ -1,0 +1,18 @@
+{
+  "id": "fd1283adb55eb70bc30ab1edbb2fe1ac611ba326821d333456fe9bf713440d6b",
+  "type": "TasArtifact",
+  "form_id": "838d38cc54b7a55760a12a6d958ef1425caa83841cfa6161d32ada370ec9c4bf",
+  "genome_id": "TAS_GENOME_V1",
+  "lineage_id": "fd1283adb55eb70bc30ab1edbb2fe1ac611ba326821d333456fe9bf713440d6b",
+  "h_seed": "Russell Nordland",
+  "cert_id": "0b5284e6-c0d1-4f37-bdef-080912151038",
+  "timestamp": "2026-06-23T01:33:55.982274+00:00",
+  "paradata_trail": [],
+  "signatures": [
+    {
+      "signer": "Russell Nordland",
+      "algorithm": "TAS_HUMAN_SIG_V1",
+      "value": "signed_by_ceremony"
+    }
+  ]
+}

--- a/tas-stack/templates/pii-scanner-service.yaml.tasmeta.json
+++ b/tas-stack/templates/pii-scanner-service.yaml.tasmeta.json
@@ -1,0 +1,18 @@
+{
+  "id": "003127ffd39a133e2e3fad4fd60fe45736f4735898ff4578ed5bdfba43474740",
+  "type": "TasArtifact",
+  "form_id": "1ee1b6a7f5261e52d00c10d033e4302550109c3a11b76e86f5510b06536e9b20",
+  "genome_id": "TAS_GENOME_V1",
+  "lineage_id": "003127ffd39a133e2e3fad4fd60fe45736f4735898ff4578ed5bdfba43474740",
+  "h_seed": "Russell Nordland",
+  "cert_id": "7b651e33-c44b-4f2c-89ea-edffc687da5f",
+  "timestamp": "2026-06-23T01:33:55.616582+00:00",
+  "paradata_trail": [],
+  "signatures": [
+    {
+      "signer": "Russell Nordland",
+      "algorithm": "TAS_HUMAN_SIG_V1",
+      "value": "signed_by_ceremony"
+    }
+  ]
+}

--- a/tas-stack/values.yaml.tasmeta.json
+++ b/tas-stack/values.yaml.tasmeta.json
@@ -1,0 +1,18 @@
+{
+  "id": "64982cecba33a33748fc3d9cd2e272f6bace3eff59b8a975c859531e06f72b88",
+  "type": "TasArtifact",
+  "form_id": "9219c7f77b980a5918d7e09253cb88c30fa291bfb7bb6b885cd4c0c5fcfe24f8",
+  "genome_id": "TAS_GENOME_V1",
+  "lineage_id": "64982cecba33a33748fc3d9cd2e272f6bace3eff59b8a975c859531e06f72b88",
+  "h_seed": "Russell Nordland",
+  "cert_id": "5baa9c5c-86e4-4a91-a1da-218c5f13fb47",
+  "timestamp": "2026-06-23T01:33:54.744461+00:00",
+  "paradata_trail": [],
+  "signatures": [
+    {
+      "signer": "Russell Nordland",
+      "algorithm": "TAS_HUMAN_SIG_V1",
+      "value": "signed_by_ceremony"
+    }
+  ]
+}

--- a/tas_1st_principles.yaml.tasmeta.json
+++ b/tas_1st_principles.yaml.tasmeta.json
@@ -1,0 +1,18 @@
+{
+  "id": "a0a8fd40a04f04fb3eb5da4184abf354bf339ddf60128c6020b1e46c8387be8f",
+  "type": "TasArtifact",
+  "form_id": "e77a67e1a716078cdb6be31e8fae3929f0d1089734839e8daa0962dca00cffc7",
+  "genome_id": "TAS_GENOME_V1",
+  "lineage_id": "a0a8fd40a04f04fb3eb5da4184abf354bf339ddf60128c6020b1e46c8387be8f",
+  "h_seed": "Russell Nordland",
+  "cert_id": "48f5faa2-fd5f-437a-a4f1-1f66db0c1c12",
+  "timestamp": "2026-06-23T01:33:37.093855+00:00",
+  "paradata_trail": [],
+  "signatures": [
+    {
+      "signer": "Russell Nordland",
+      "algorithm": "TAS_HUMAN_SIG_V1",
+      "value": "signed_by_ceremony"
+    }
+  ]
+}

--- a/tas_citation_registry.yaml.tasmeta.json
+++ b/tas_citation_registry.yaml.tasmeta.json
@@ -1,0 +1,18 @@
+{
+  "id": "b1d9733e7d4f8bcc14048fa940a113aed3f616393b2b8b167bc890e9847248ad",
+  "type": "TasArtifact",
+  "form_id": "337c96e1e8f40181859d3f243673ed28ae48f20a2d5a9a501bb55c7778a65922",
+  "genome_id": "TAS_GENOME_V1",
+  "lineage_id": "b1d9733e7d4f8bcc14048fa940a113aed3f616393b2b8b167bc890e9847248ad",
+  "h_seed": "Russell Nordland",
+  "cert_id": "6f86c7c2-77bb-428c-9c58-952310ac8495",
+  "timestamp": "2026-06-23T01:33:39.767417+00:00",
+  "paradata_trail": [],
+  "signatures": [
+    {
+      "signer": "Russell Nordland",
+      "algorithm": "TAS_HUMAN_SIG_V1",
+      "value": "signed_by_ceremony"
+    }
+  ]
+}

--- a/tas_dna_doi_package_v0.1/LICENSE_RIDER.txt.tasmeta.json
+++ b/tas_dna_doi_package_v0.1/LICENSE_RIDER.txt.tasmeta.json
@@ -1,0 +1,18 @@
+{
+  "id": "487ac7cc15dc748fea78baf5fa00c121dcf494b0cde380850e2babed4584ca0c",
+  "type": "TasArtifact",
+  "form_id": "51b171cf725e365f1bc3cad9531d08501d4ca4fc6cc79ca683b5a2949c274000",
+  "genome_id": "TAS_GENOME_V1",
+  "lineage_id": "487ac7cc15dc748fea78baf5fa00c121dcf494b0cde380850e2babed4584ca0c",
+  "h_seed": "Russell Nordland",
+  "cert_id": "9dac4b06-82b6-4e4f-aa6e-60dd2092bdd2",
+  "timestamp": "2026-06-23T01:33:50.514737+00:00",
+  "paradata_trail": [],
+  "signatures": [
+    {
+      "signer": "Russell Nordland",
+      "algorithm": "TAS_HUMAN_SIG_V1",
+      "value": "signed_by_ceremony"
+    }
+  ]
+}

--- a/tas_dna_doi_package_v0.1/README.md.tasmeta.json
+++ b/tas_dna_doi_package_v0.1/README.md.tasmeta.json
@@ -1,0 +1,18 @@
+{
+  "id": "ee8be6888bec78f5f331978537a4a01d84ca28d948fb99a32178410301e7e379",
+  "type": "TasArtifact",
+  "form_id": "e81168d58855121aafd19a3ffa6804749c9a1f45dfbcd3f22dafd91538e169a8",
+  "genome_id": "TAS_GENOME_V1",
+  "lineage_id": "ee8be6888bec78f5f331978537a4a01d84ca28d948fb99a32178410301e7e379",
+  "h_seed": "Russell Nordland",
+  "cert_id": "d41113d2-4cf3-4dfc-b3ca-ac55dd49762a",
+  "timestamp": "2026-06-23T01:33:50.154030+00:00",
+  "paradata_trail": [],
+  "signatures": [
+    {
+      "signer": "Russell Nordland",
+      "algorithm": "TAS_HUMAN_SIG_V1",
+      "value": "signed_by_ceremony"
+    }
+  ]
+}

--- a/tas_dna_doi_package_v0.1/README_OAI_ICF.txt.tasmeta.json
+++ b/tas_dna_doi_package_v0.1/README_OAI_ICF.txt.tasmeta.json
@@ -1,0 +1,18 @@
+{
+  "id": "2dc839e899b842a79969e1d12a5302664ae3c596b7327432ba70333312a6c674",
+  "type": "TasArtifact",
+  "form_id": "d25d96acd779412985d4213062e1e45fc8ab1f352978e1386582de2d9bea26d7",
+  "genome_id": "TAS_GENOME_V1",
+  "lineage_id": "2dc839e899b842a79969e1d12a5302664ae3c596b7327432ba70333312a6c674",
+  "h_seed": "Russell Nordland",
+  "cert_id": "7cc250e3-fd40-4071-b7ec-9ef8d9543ec5",
+  "timestamp": "2026-06-23T01:33:49.428795+00:00",
+  "paradata_trail": [],
+  "signatures": [
+    {
+      "signer": "Russell Nordland",
+      "algorithm": "TAS_HUMAN_SIG_V1",
+      "value": "signed_by_ceremony"
+    }
+  ]
+}

--- a/tas_dna_doi_package_v0.1/citation.bib.tasmeta.json
+++ b/tas_dna_doi_package_v0.1/citation.bib.tasmeta.json
@@ -1,0 +1,18 @@
+{
+  "id": "c49fe3232bc92e202c53c22d4e86c6281daf1135f379805ac95e7cb4a066753f",
+  "type": "TasArtifact",
+  "form_id": "6d43e1855c9305db1616cfa075a410a9aa1061215e33a391084bc5bca6abd477",
+  "genome_id": "TAS_GENOME_V1",
+  "lineage_id": "c49fe3232bc92e202c53c22d4e86c6281daf1135f379805ac95e7cb4a066753f",
+  "h_seed": "Russell Nordland",
+  "cert_id": "1889a00c-bf89-44d6-ad8f-26469f019630",
+  "timestamp": "2026-06-23T01:33:49.063105+00:00",
+  "paradata_trail": [],
+  "signatures": [
+    {
+      "signer": "Russell Nordland",
+      "algorithm": "TAS_HUMAN_SIG_V1",
+      "value": "signed_by_ceremony"
+    }
+  ]
+}

--- a/tas_dna_doi_package_v0.1/schemas/tas_meta_schema.json.tasmeta.json
+++ b/tas_dna_doi_package_v0.1/schemas/tas_meta_schema.json.tasmeta.json
@@ -1,0 +1,18 @@
+{
+  "id": "412e5600c6be7406756dbdf54d9ce02b5efe700db145cbac21dbcc2745adf33b",
+  "type": "TasArtifact",
+  "form_id": "f8b62a4b649e175f332d131e20c9afc5881f2e52499a7090042e73689d039b59",
+  "genome_id": "TAS_GENOME_V1",
+  "lineage_id": "412e5600c6be7406756dbdf54d9ce02b5efe700db145cbac21dbcc2745adf33b",
+  "h_seed": "Russell Nordland",
+  "cert_id": "bee26b15-327c-4e47-b984-755a51fdfd85",
+  "timestamp": "2026-06-23T01:33:50.875618+00:00",
+  "paradata_trail": [],
+  "signatures": [
+    {
+      "signer": "Russell Nordland",
+      "algorithm": "TAS_HUMAN_SIG_V1",
+      "value": "signed_by_ceremony"
+    }
+  ]
+}

--- a/tas_dna_doi_package_v0.1/zenodo_metadata.json.tasmeta.json
+++ b/tas_dna_doi_package_v0.1/zenodo_metadata.json.tasmeta.json
@@ -1,0 +1,18 @@
+{
+  "id": "53d048ddeaec0735fe1afd98588cbbba1717e957a72216c407bee24d8e6ae192",
+  "type": "TasArtifact",
+  "form_id": "77cf72025496045c4b9a0acbdbb3620e888a70f0ca67f5fb15291948f9764214",
+  "genome_id": "TAS_GENOME_V1",
+  "lineage_id": "53d048ddeaec0735fe1afd98588cbbba1717e957a72216c407bee24d8e6ae192",
+  "h_seed": "Russell Nordland",
+  "cert_id": "f063962c-3161-4dcd-808d-9abcb610fc95",
+  "timestamp": "2026-06-23T01:33:49.793910+00:00",
+  "paradata_trail": [],
+  "signatures": [
+    {
+      "signer": "Russell Nordland",
+      "algorithm": "TAS_HUMAN_SIG_V1",
+      "value": "signed_by_ceremony"
+    }
+  ]
+}

--- a/tas_pythonetics/CHANGELOG.md.tasmeta.json
+++ b/tas_pythonetics/CHANGELOG.md.tasmeta.json
@@ -1,0 +1,18 @@
+{
+  "id": "62e62d1d0256c17fe17dd9eaf3c4ad3a7a4820fa3a64bd4cb14c3bf7ab564de4",
+  "type": "TasArtifact",
+  "form_id": "d94a27b2bbe609b5afa70545132814f54165d6635f7c4a4b21644d06f1ca0764",
+  "genome_id": "TAS_GENOME_V1",
+  "lineage_id": "62e62d1d0256c17fe17dd9eaf3c4ad3a7a4820fa3a64bd4cb14c3bf7ab564de4",
+  "h_seed": "Russell Nordland",
+  "cert_id": "598aeecb-4cb9-468a-80e4-b131751780b7",
+  "timestamp": "2026-06-23T01:33:58.131400+00:00",
+  "paradata_trail": [],
+  "signatures": [
+    {
+      "signer": "Russell Nordland",
+      "algorithm": "TAS_HUMAN_SIG_V1",
+      "value": "signed_by_ceremony"
+    }
+  ]
+}

--- a/tas_pythonetics/README.md.tasmeta.json
+++ b/tas_pythonetics/README.md.tasmeta.json
@@ -1,0 +1,18 @@
+{
+  "id": "e3a33daf7901aff06f8901c8e33399ea73985dfea013e01a2b783acb4c17f5bc",
+  "type": "TasArtifact",
+  "form_id": "0ccd19e7ee38f7a026b3121594f6074f856a2fb10981e0841165ea587bb99155",
+  "genome_id": "TAS_GENOME_V1",
+  "lineage_id": "e3a33daf7901aff06f8901c8e33399ea73985dfea013e01a2b783acb4c17f5bc",
+  "h_seed": "Russell Nordland",
+  "cert_id": "54130bc0-877e-4652-9b84-fa70f4c20853",
+  "timestamp": "2026-06-23T01:33:58.869609+00:00",
+  "paradata_trail": [],
+  "signatures": [
+    {
+      "signer": "Russell Nordland",
+      "algorithm": "TAS_HUMAN_SIG_V1",
+      "value": "signed_by_ceremony"
+    }
+  ]
+}

--- a/tas_pythonetics/manifesto/Pythonetics_Manifesto.md.tasmeta.json
+++ b/tas_pythonetics/manifesto/Pythonetics_Manifesto.md.tasmeta.json
@@ -1,0 +1,18 @@
+{
+  "id": "ac7a9827eb9c1f19b48f12878c61b989726de1956b34b8287ee38394a8309d2c",
+  "type": "TasArtifact",
+  "form_id": "eafae2abe57d3353af6e32978387892e2491e06d27cb03caa91aec13233e2395",
+  "genome_id": "TAS_GENOME_V1",
+  "lineage_id": "ac7a9827eb9c1f19b48f12878c61b989726de1956b34b8287ee38394a8309d2c",
+  "h_seed": "Russell Nordland",
+  "cert_id": "8ac23c37-7785-4246-abbd-843701a0f431",
+  "timestamp": "2026-06-23T01:33:59.216830+00:00",
+  "paradata_trail": [],
+  "signatures": [
+    {
+      "signer": "Russell Nordland",
+      "algorithm": "TAS_HUMAN_SIG_V1",
+      "value": "signed_by_ceremony"
+    }
+  ]
+}

--- a/tas_pythonetics/pyproject.toml.tasmeta.json
+++ b/tas_pythonetics/pyproject.toml.tasmeta.json
@@ -1,0 +1,18 @@
+{
+  "id": "fdd7eaa02c15d1bf20a32dd479aa64b0c0ff136a8215e8460b9d707bb34adfaf",
+  "type": "TasArtifact",
+  "form_id": "c3676f16e1f70222626ff74cdb4c74c40fabb261b3b7c0bd6a59199255313071",
+  "genome_id": "TAS_GENOME_V1",
+  "lineage_id": "fdd7eaa02c15d1bf20a32dd479aa64b0c0ff136a8215e8460b9d707bb34adfaf",
+  "h_seed": "Russell Nordland",
+  "cert_id": "217787cc-ae63-4c48-ab6b-6add16f5295e",
+  "timestamp": "2026-06-23T01:33:58.518873+00:00",
+  "paradata_trail": [],
+  "signatures": [
+    {
+      "signer": "Russell Nordland",
+      "algorithm": "TAS_HUMAN_SIG_V1",
+      "value": "signed_by_ceremony"
+    }
+  ]
+}

--- a/threshold.tasmeta.json
+++ b/threshold.tasmeta.json
@@ -1,0 +1,18 @@
+{
+  "id": "e21d3d03455fafe8323c9cee57b25d2842f28dbd578676ff18fc44e5d7fb8ad7",
+  "type": "TasArtifact",
+  "form_id": "5bc108ed7848783f865e9ad7e3488c96ed422458a0f542a1a1983985fe99f3d4",
+  "genome_id": "TAS_GENOME_V1",
+  "lineage_id": "e21d3d03455fafe8323c9cee57b25d2842f28dbd578676ff18fc44e5d7fb8ad7",
+  "h_seed": "Russell Nordland",
+  "cert_id": "9e334fc7-19f9-4558-abbe-f0fc0e179198",
+  "timestamp": "2026-06-23T01:33:42.411872+00:00",
+  "paradata_trail": [],
+  "signatures": [
+    {
+      "signer": "Russell Nordland",
+      "algorithm": "TAS_HUMAN_SIG_V1",
+      "value": "signed_by_ceremony"
+    }
+  ]
+}

--- a/valid_identity.txt.tasmeta.json
+++ b/valid_identity.txt.tasmeta.json
@@ -1,0 +1,18 @@
+{
+  "id": "c0466bde22bcd68387da96a624a65f31d52b84bb40660809fcccd5250ae53c9c",
+  "type": "TasArtifact",
+  "form_id": "c57ae407e75c5aae8d94e782272b6f5789107331aa94cabb2026f3eaa83e2edb",
+  "genome_id": "TAS_GENOME_V1",
+  "lineage_id": "c0466bde22bcd68387da96a624a65f31d52b84bb40660809fcccd5250ae53c9c",
+  "h_seed": "Russell Nordland",
+  "cert_id": "d30d3722-3d11-428c-ac34-169206868f46",
+  "timestamp": "2026-06-23T01:33:41.334360+00:00",
+  "paradata_trail": [],
+  "signatures": [
+    {
+      "signer": "Russell Nordland",
+      "algorithm": "TAS_HUMAN_SIG_V1",
+      "value": "signed_by_ceremony"
+    }
+  ]
+}

--- a/wolfram/TASEthicalCore.wl.tasmeta.json
+++ b/wolfram/TASEthicalCore.wl.tasmeta.json
@@ -1,0 +1,18 @@
+{
+  "id": "e6d91e2d4cf24c3d7ab3f9cf3267d1d4efcde8f1fa8c4e72c2a8f979a5842e77",
+  "type": "TasArtifact",
+  "form_id": "75fb59fd08da6d498b1024e75aacb3d3a92c80f99289406c626203e52e3689df",
+  "genome_id": "TAS_GENOME_V1",
+  "lineage_id": "e6d91e2d4cf24c3d7ab3f9cf3267d1d4efcde8f1fa8c4e72c2a8f979a5842e77",
+  "h_seed": "Russell Nordland",
+  "cert_id": "c0a096d3-6dbc-452f-a359-f99017af4ec2",
+  "timestamp": "2026-06-23T01:33:59.914759+00:00",
+  "paradata_trail": [],
+  "signatures": [
+    {
+      "signer": "Russell Nordland",
+      "algorithm": "TAS_HUMAN_SIG_V1",
+      "value": "signed_by_ceremony"
+    }
+  ]
+}

--- a/zenodo_metadata.json.tasmeta.json
+++ b/zenodo_metadata.json.tasmeta.json
@@ -1,0 +1,18 @@
+{
+  "id": "07343015ae0c4b8e5cdb589d4e832abcb5e65e68ae90ea5f23d23ab836faf8bd",
+  "type": "TasArtifact",
+  "form_id": "77cf72025496045c4b9a0acbdbb3620e888a70f0ca67f5fb15291948f9764214",
+  "genome_id": "TAS_GENOME_V1",
+  "lineage_id": "07343015ae0c4b8e5cdb589d4e832abcb5e65e68ae90ea5f23d23ab836faf8bd",
+  "h_seed": "Russell Nordland",
+  "cert_id": "f11367ed-4f9b-4821-ae50-b2845ee9c719",
+  "timestamp": "2026-06-23T01:33:46.440326+00:00",
+  "paradata_trail": [],
+  "signatures": [
+    {
+      "signer": "Russell Nordland",
+      "algorithm": "TAS_HUMAN_SIG_V1",
+      "value": "signed_by_ceremony"
+    }
+  ]
+}


### PR DESCRIPTION
Sequenced all TrueAlphaSpiral noise files across the codebase to join the Living Braid by generating `.tasmeta.json` sidecars for them using `tas_cli.py sequence`. Verified that `shadow-scan` reports 0 noise/drifted artifacts. All tests pass with 172/172 success rate.

---
*PR created automatically by Jules for task [9835807139831237411](https://jules.google.com/task/9835807139831237411) started by @TrueAlpha-spiral*