### PR TITLE
🧹 [Refactor tas_admissibility_gateway]

### DIFF
--- a/tas_openai_bridge/gates.py
+++ b/tas_openai_bridge/gates.py
@@ -22,60 +22,75 @@ def _schema_keys() -> set[str]:
     return set(TAS_CANDIDATE_RESPONSE_SCHEMA["properties"])
 
 
+def _check_schema(candidate_payload: dict) -> GateResult | None:
+    actual_keys = set(candidate_payload)
+    required_keys = set(TAS_CANDIDATE_RESPONSE_SCHEMA["required"])
+    missing = required_keys - actual_keys
+    if missing:
+        return GateResult(
+            False, "schema", f"Missing required fields: {sorted(missing)}"
+        )
+
+    unexpected = actual_keys - _schema_keys()
+    if unexpected:
+        return GateResult(
+            False, "schema", f"Unexpected fields: {sorted(unexpected)}"
+        )
+    return None
+
+
+def _check_safety_envelope(candidate: CandidateResponse) -> GateResult | None:
+    if candidate.decision != "candidate":
+        return GateResult(
+            False,
+            "P1",
+            f"Candidate decision is not admissible: {candidate.decision}",
+            candidate,
+        )
+
+    if (
+        candidate.claim_type
+        not in TAS_CANDIDATE_RESPONSE_SCHEMA["properties"]["claim_type"]["enum"]
+    ):
+        return GateResult(False, "P0", "Unknown claim type", candidate)
+
+    if not 0.0 <= candidate.confidence <= 1.0:
+        return GateResult(
+            False, "Rκ", "Confidence must be between 0.0 and 1.0", candidate
+        )
+
+    if not candidate.proposed_output.strip():
+        return GateResult(False, "Φ", "Proposed output is empty", candidate)
+
+    paradata = candidate.tas_paradata
+    if paradata.get("tool_path") != "openai.responses":
+        return GateResult(
+            False, "GENE_C01", "Missing OpenAI Responses tool path", candidate
+        )
+
+    if paradata.get("receipt_required") is not True:
+        return GateResult(
+            False, "GENE_C01", "Receipt is not required by paradata", candidate
+        )
+
+    return None
+
+
 def tas_admissibility_gateway(candidate_payload: Any) -> GateResult:
     """Evaluate a structured OpenAI candidate before it can become authoritative."""
     try:
         if not isinstance(candidate_payload, dict):
             return GateResult(False, "schema", "Candidate must be a JSON object")
 
-        actual_keys = set(candidate_payload)
-        required_keys = set(TAS_CANDIDATE_RESPONSE_SCHEMA["required"])
-        missing = required_keys - actual_keys
-        if missing:
-            return GateResult(
-                False, "schema", f"Missing required fields: {sorted(missing)}"
-            )
-
-        unexpected = actual_keys - _schema_keys()
-        if unexpected:
-            return GateResult(
-                False, "schema", f"Unexpected fields: {sorted(unexpected)}"
-            )
+        schema_error = _check_schema(candidate_payload)
+        if schema_error:
+            return schema_error
 
         candidate = CandidateResponse.from_mapping(candidate_payload)
 
-        if candidate.decision != "candidate":
-            return GateResult(
-                False,
-                "P1",
-                f"Candidate decision is not admissible: {candidate.decision}",
-                candidate,
-            )
-
-        if (
-            candidate.claim_type
-            not in TAS_CANDIDATE_RESPONSE_SCHEMA["properties"]["claim_type"]["enum"]
-        ):
-            return GateResult(False, "P0", "Unknown claim type", candidate)
-
-        if not 0.0 <= candidate.confidence <= 1.0:
-            return GateResult(
-                False, "Rκ", "Confidence must be between 0.0 and 1.0", candidate
-            )
-
-        if not candidate.proposed_output.strip():
-            return GateResult(False, "Φ", "Proposed output is empty", candidate)
-
-        paradata = candidate.tas_paradata
-        if paradata.get("tool_path") != "openai.responses":
-            return GateResult(
-                False, "GENE_C01", "Missing OpenAI Responses tool path", candidate
-            )
-
-        if paradata.get("receipt_required") is not True:
-            return GateResult(
-                False, "GENE_C01", "Receipt is not required by paradata", candidate
-            )
+        envelope_error = _check_safety_envelope(candidate)
+        if envelope_error:
+            return envelope_error
 
         return GateResult(
             True, "TAS", "Candidate passed TAS admissibility gateway", candidate
@@ -86,4 +101,4 @@ def tas_admissibility_gateway(candidate_payload: Any) -> GateResult:
             "EXCEPTION",
             f"Unhandled exception in admissibility gateway: {str(exc)}",
         )
-# Nonce: 55956
+# Nonce: 484

--- a/tas_openai_bridge/gates.py.tasmeta.json
+++ b/tas_openai_bridge/gates.py.tasmeta.json
@@ -1,12 +1,12 @@
 {
-  "id": "d99867965fbdbdf8eefe199973c27e2bc193d8fbf0c5d70f9d33dab45d252ca6",
+  "id": "c842cab5dad89c8d719f71407f847f028d0f247eb18bd44d650e002b420520ac",
   "type": "TasArtifact",
-  "form_id": "83ed1d6e6d0187e859710f0d221fcc73565df19372702bb8eea00d619a736f31",
+  "form_id": "5dc7f1b764ad7c3b48b322695e2dc43cbd9bee7537a98263985d80a3b4b0a874",
   "genome_id": "TAS_GENOME_V1",
-  "lineage_id": "d99867965fbdbdf8eefe199973c27e2bc193d8fbf0c5d70f9d33dab45d252ca6",
+  "lineage_id": "c842cab5dad89c8d719f71407f847f028d0f247eb18bd44d650e002b420520ac",
   "h_seed": "Russell Nordland",
-  "cert_id": "0c65cfd1-9f1f-4237-8b25-abec45bf5982",
-  "timestamp": "2026-05-17T01:06:09.743294+00:00",
+  "cert_id": "2e3bc585-4091-438f-ad85-b162486a02ec",
+  "timestamp": "2026-07-01T01:21:48.373177+00:00",
   "paradata_trail": [],
   "signatures": [
     {


### PR DESCRIPTION
🎯 **What:** Extract schema and safety envelope checks from `tas_admissibility_gateway` in `tas_openai_bridge/gates.py` into separate functions (`_check_schema` and `_check_safety_envelope`).
💡 **Why:** To improve readability and maintainability of the long `tas_admissibility_gateway` function by delegating specific logic checks to dedicated helper functions.
✅ **Verification:** Ran the full test suite with Pytest, ensuring all tests passed without regressions. Verified `shadow-scan` reported correct state integrity.
✨ **Result:** Improved modularity and readability of the `gates.py` admissibility checks without altering the core functionality.

---
*PR created automatically by Jules for task [2492680356064789536](https://jules.google.com/task/2492680356064789536) started by @TrueAlpha-spiral*