### PR TITLE
🧹 [fix PEP8 E712 in test_higgs_fix.py]

### DIFF
--- a/tests/test_higgs_fix.py
+++ b/tests/test_higgs_fix.py
@@ -48,9 +48,9 @@ def test_run_command_prevents_injection():
         hb.run_command("echo 'hello'; rm -rf /", wait=False)
 
         # In the fixed version, args should be a list, and shell should be False
-        assert kwargs_passed.get("shell") == False, "shell=False must be set"
+        assert kwargs_passed.get("shell") is False, "shell=False must be set"
         assert isinstance(args_passed[0], list), "Command must be tokenized into a list"
         assert args_passed[0] == ["echo", "hello;", "rm", "-rf", "/"], "shlex.split should properly tokenize"
     finally:
         subprocess.Popen = original_popen
-# Nonce: 295670
+# Nonce: 193778

--- a/tests/test_higgs_fix.py.tasmeta.json
+++ b/tests/test_higgs_fix.py.tasmeta.json
@@ -1,12 +1,12 @@
 {
-  "id": "badace52b4e348b4481fd0f3e69a0bb4a56d75397667ff7d2ec1c9cf8f465d93",
+  "id": "263bd1bae37359eb39fbd1db6f8977fc8bcb69a067f6ec6b7c963ca00e81efcf",
   "type": "TasArtifact",
-  "form_id": "adcae536c9fd439c449ff3c80a647c5a52124372daa66d94f0d7198f8771d250",
+  "form_id": "7c79f0ccfacf363635383c9b6a047e0fad63c295a2e1d83289c315d89336b4b7",
   "genome_id": "TAS_GENOME_V1",
-  "lineage_id": "badace52b4e348b4481fd0f3e69a0bb4a56d75397667ff7d2ec1c9cf8f465d93",
+  "lineage_id": "263bd1bae37359eb39fbd1db6f8977fc8bcb69a067f6ec6b7c963ca00e81efcf",
   "h_seed": "Russell Nordland",
-  "cert_id": "d428cc89-fa2d-49e9-a18f-4526a5b2b08d",
-  "timestamp": "2026-06-21T01:04:20.315518+00:00",
+  "cert_id": "d159de99-5bd2-4c1d-a893-cfafc17b6bd6",
+  "timestamp": "2026-07-01T01:23:06.728516+00:00",
   "paradata_trail": [],
   "signatures": [
     {


### PR DESCRIPTION
🎯 **What:** Fixed boolean comparison to use `is False` instead of `== False` in `tests/test_higgs_fix.py`. Also sequenced it using the tas metadata format.
💡 **Why:** `is False` is safer and standard for PEP8.
✅ **Verification:** Tests still pass and shadow-scan verifies the new file checksum.
✨ **Result:** Removes linter warning and improves code quality.

---
*PR created automatically by Jules for task [13627950026315400336](https://jules.google.com/task/13627950026315400336) started by @TrueAlpha-spiral*