### PR TITLE
🧹 [code health improvement] Refactor tas_openai_execute into helper functions

### DIFF
--- a/tas_openai_bridge/bridge.py
+++ b/tas_openai_bridge/bridge.py
@@ -65,6 +65,52 @@ def _default_client() -> Any | RefusalArtifact:
     return OpenAI()
 
 
+def _check_authority(
+    human_api_key: HumanAPIKey | None, scoped_authority: ScopedAuthority | None
+) -> RefusalArtifact | None:
+    if human_api_key is None or scoped_authority is None:
+        return RefusalArtifact(reason="Missing authority anchor")
+
+    if not human_api_key.validate():
+        return RefusalArtifact(reason="Invalid HumanAPI Key")
+
+    if not scoped_authority.allows(OPENAI_RESPONSES_ACTION):
+        return RefusalArtifact(reason="Scope does not authorize OpenAI execution")
+
+    return None
+
+
+def _build_conduit_payload(prompt: str, prompt_hash: str, model: str) -> str:
+    return json.dumps(
+        {
+            "prompt": prompt,
+            "tas_paradata_requirements": {
+                "input_hash": prompt_hash,
+                "model": model,
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "tool_path": "openai.responses",
+                "receipt_required": True,
+            },
+        },
+        sort_keys=True,
+    )
+
+
+def _parse_candidate_payload(
+    response: Any, prompt_hash: str, model: str
+) -> dict[str, Any] | RefusalArtifact:
+    candidate = _candidate_from_response(response)
+    if isinstance(candidate, RefusalArtifact):
+        return candidate
+
+    candidate.setdefault("tas_paradata", {})["input_hash"] = prompt_hash
+    candidate["tas_paradata"].setdefault("model", model)
+    candidate["tas_paradata"].setdefault("tool_path", "openai.responses")
+    candidate["tas_paradata"].setdefault("receipt_required", True)
+
+    return candidate
+
+
 def tas_openai_execute(
     human_api_key: HumanAPIKey | None,
     scoped_authority: ScopedAuthority | None,
@@ -80,33 +126,16 @@ def tas_openai_execute(
     RefusalArtifact instead of allowing raw crashes or silent acceptance.
     """
     try:
-        if human_api_key is None or scoped_authority is None:
-            return RefusalArtifact(reason="Missing authority anchor")
-
-        if not human_api_key.validate():
-            return RefusalArtifact(reason="Invalid HumanAPI Key")
-
-        if not scoped_authority.allows(OPENAI_RESPONSES_ACTION):
-            return RefusalArtifact(reason="Scope does not authorize OpenAI execution")
+        authority_refusal = _check_authority(human_api_key, scoped_authority)
+        if authority_refusal:
+            return authority_refusal
 
         execution_client = client if client is not None else _default_client()
         if isinstance(execution_client, RefusalArtifact):
             return execution_client
 
         prompt_hash = _hash_prompt(prompt)
-        conduit_prompt = json.dumps(
-            {
-                "prompt": prompt,
-                "tas_paradata_requirements": {
-                    "input_hash": prompt_hash,
-                    "model": model,
-                    "timestamp": datetime.now(timezone.utc).isoformat(),
-                    "tool_path": "openai.responses",
-                    "receipt_required": True,
-                },
-            },
-            sort_keys=True,
-        )
+        conduit_prompt = _build_conduit_payload(prompt, prompt_hash, model)
 
         try:
             response = execution_client.responses.create(
@@ -120,14 +149,9 @@ def tas_openai_execute(
                 details={"stage": "openai.responses.create", "error": str(exc)},
             )
 
-        candidate = _candidate_from_response(response)
+        candidate = _parse_candidate_payload(response, prompt_hash, model)
         if isinstance(candidate, RefusalArtifact):
             return candidate
-
-        candidate.setdefault("tas_paradata", {})["input_hash"] = prompt_hash
-        candidate["tas_paradata"].setdefault("model", model)
-        candidate["tas_paradata"].setdefault("tool_path", "openai.responses")
-        candidate["tas_paradata"].setdefault("receipt_required", True)
 
         gate_result = tas_admissibility_gateway(candidate)
         if not gate_result.admissible:

--- a/tas_openai_bridge/bridge.py.tasmeta.json
+++ b/tas_openai_bridge/bridge.py.tasmeta.json
@@ -1,12 +1,12 @@
 {
-  "id": "81d2db8f7f2c128ad026f6ac4e6874ccd7dbf3624be7fadeb3c9cae7741cf8c9",
+  "id": "3d747311f5f104ad651af78e6241e5293a563ae45e3a3b68c5cf786b402106b2",
   "type": "TasArtifact",
-  "form_id": "8a3bc3bb33a5f2e7df09f1f113eb1bea80a5e03365462a0b377417d2cfdeeb7b",
+  "form_id": "2a129c2fd6cfee958cc40e08ced428ce7b0a126bb1c38db8a61079d7bda8e88d",
   "genome_id": "TAS_GENOME_V1",
-  "lineage_id": "81d2db8f7f2c128ad026f6ac4e6874ccd7dbf3624be7fadeb3c9cae7741cf8c9",
+  "lineage_id": "3d747311f5f104ad651af78e6241e5293a563ae45e3a3b68c5cf786b402106b2",
   "h_seed": "Russell Nordland",
-  "cert_id": "19b7d239-2c03-4052-8948-0d6d2be9af76",
-  "timestamp": "2026-05-17T01:07:27.446907+00:00",
+  "cert_id": "9485f43b-15dd-4593-88ff-69c8651aed0e",
+  "timestamp": "2026-07-01T01:25:47.915114+00:00",
   "paradata_trail": [],
   "signatures": [
     {

--- a/worm_ledger_mock.json.tasmeta.json
+++ b/worm_ledger_mock.json.tasmeta.json
@@ -1,12 +1,12 @@
 {
-  "id": "6cd3753c70c9e17da725e97a04b698b24490156639d6b30a57b15bb22b67f612",
+  "id": "40196922405da45d2e7c1fc876812091da71e5ae7b16774715c646feef43b257",
   "type": "TasArtifact",
-  "form_id": "7e2f59500ce13162c69c231bdfe3dcc0b5337ff2362871dfb27cff8d055d037d",
+  "form_id": "3436f12f775e250d53186c4e7e1b9581d8d67031548b9b4f2cd924bf91936a7c",
   "genome_id": "TAS_GENOME_V1",
-  "lineage_id": "6cd3753c70c9e17da725e97a04b698b24490156639d6b30a57b15bb22b67f612",
+  "lineage_id": "40196922405da45d2e7c1fc876812091da71e5ae7b16774715c646feef43b257",
   "h_seed": "Russell Nordland",
-  "cert_id": "c259d296-2c63-4f0e-a248-1ae36f8cbb50",
-  "timestamp": "2026-06-28T01:08:49.065486+00:00",
+  "cert_id": "977f0acb-f3d5-408d-85d9-0d495bfdb9c2",
+  "timestamp": "2026-07-01T01:26:16.612143+00:00",
   "paradata_trail": [],
   "signatures": [
     {


### PR DESCRIPTION
🎯 **What:** The `tas_openai_execute` function in `tas_openai_bridge/bridge.py` was too long and complex. This PR extracts the authority checks and payload construction/parsing into three dedicated helper functions: `_check_authority`, `_build_conduit_payload`, and `_parse_candidate_payload`.

💡 **Why:** Breaking down the monolithic function significantly improves code readability and makes the bridge component easier to maintain.

✅ **Verification:** I verified the changes by:
- Visually inspecting the refactored code to ensure the logic remains identical.
- Running the full pytest suite (`python3 -m pytest`) to guarantee no functionality was broken.
- Sequencing the updated files using the TAS CLI to ensure kinematic identity is properly tracked.

✨ **Result:** The `tas_openai_execute` function is now much cleaner and easier to follow, with the extracted logic encapsulated in well-named helper functions, without any change to the existing behavior.

---
*PR created automatically by Jules for task [18142849821507376112](https://jules.google.com/task/18142849821507376112) started by @TrueAlpha-spiral*