### PR TITLE
🧹 [test sentient lock cleanup]

### DIFF
--- a/tas_pythonetics/tests/test_sentient_lock.py
+++ b/tas_pythonetics/tests/test_sentient_lock.py
@@ -83,12 +83,12 @@ class TestSentientLock(unittest.TestCase):
     def test_verify_kinematic_identity_fail(self):
         # Mock sha256 to return a hash with incorrect prefix
         mock_hash = MagicMock()
-        mock_hash.hexdigest.return_value = "0000abcdef123456" # Not 1618
+        mock_hash.hexdigest.return_value = "0000abcdef123456" # Not TAS_KINEMATIC_PREFIX
 
         with patch('hashlib.sha256', return_value=mock_hash):
             with self.assertRaises(PhoenixError) as cm:
                 verify_kinematic_identity("invalid_data")
-            self.assertIn("Expected prefix '1618'", str(cm.exception))
+            self.assertIn(f"Expected prefix '{TAS_KINEMATIC_PREFIX}'", str(cm.exception))
 
     def test_verify_kinematic_identity_signature(self):
         # Ensure signature is used in payload
@@ -107,4 +107,4 @@ class TestSentientLock(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
-# Nonce: 55579
+# Nonce: 8349

--- a/tas_pythonetics/tests/test_sentient_lock.py
+++ b/tas_pythonetics/tests/test_sentient_lock.py
@@ -83,7 +83,8 @@ class TestSentientLock(unittest.TestCase):
     def test_verify_kinematic_identity_fail(self):
         # Mock sha256 to return a hash with incorrect prefix
         mock_hash = MagicMock()
-        mock_hash.hexdigest.return_value = "0000abcdef123456" # Not TAS_KINEMATIC_PREFIX
+        bad_prefix = "0" if TAS_KINEMATIC_PREFIX[0] != "0" else "1"
+        mock_hash.hexdigest.return_value = f"{bad_prefix}000abcdef123456"
 
         with patch('hashlib.sha256', return_value=mock_hash):
             with self.assertRaises(PhoenixError) as cm:

--- a/tas_pythonetics/tests/test_sentient_lock.py.tasmeta.json
+++ b/tas_pythonetics/tests/test_sentient_lock.py.tasmeta.json
@@ -1,12 +1,12 @@
 {
-  "id": "b3b8cbc8e9c09b8cd35938f7f14003b4598e30b8811083977737840a53b937dc",
+  "id": "d39b03c2fe3223bb306197f163fd9c1a2880149f34f3cf1bb097287189dba771",
   "type": "TasArtifact",
-  "form_id": "b8e1aaa3215d2faea4bf35cf3f31c1787a27336acb497eeca39d68862857da9b",
+  "form_id": "1b9c100267b4b5723a0cdff37d1191efaad1bb5e52d51f09c7e1b03fc524f728",
   "genome_id": "TAS_GENOME_V1",
-  "lineage_id": "b3b8cbc8e9c09b8cd35938f7f14003b4598e30b8811083977737840a53b937dc",
+  "lineage_id": "d39b03c2fe3223bb306197f163fd9c1a2880149f34f3cf1bb097287189dba771",
   "h_seed": "Russell Nordland",
-  "cert_id": "53c08427-9c84-4285-bcca-349e1c8e2891",
-  "timestamp": "2026-06-21T01:04:18.019300+00:00",
+  "cert_id": "0cfa4391-85f1-4b7d-acb1-57064c36d306",
+  "timestamp": "2026-07-01T01:25:04.326327+00:00",
   "paradata_trail": [],
   "signatures": [
     {

--- a/worm_ledger_mock.json.tasmeta.json
+++ b/worm_ledger_mock.json.tasmeta.json
@@ -1,12 +1,12 @@
 {
-  "id": "6cd3753c70c9e17da725e97a04b698b24490156639d6b30a57b15bb22b67f612",
+  "id": "385fe8da4f7612d59bc1d4a65b5b904bd6ab285a71ab5de8e10baf3c1ed33834",
   "type": "TasArtifact",
-  "form_id": "7e2f59500ce13162c69c231bdfe3dcc0b5337ff2362871dfb27cff8d055d037d",
+  "form_id": "88eafc8e97975a5be195b5f013577363ff989f53a7e23462072aa950f0b6442d",
   "genome_id": "TAS_GENOME_V1",
-  "lineage_id": "6cd3753c70c9e17da725e97a04b698b24490156639d6b30a57b15bb22b67f612",
+  "lineage_id": "385fe8da4f7612d59bc1d4a65b5b904bd6ab285a71ab5de8e10baf3c1ed33834",
   "h_seed": "Russell Nordland",
-  "cert_id": "c259d296-2c63-4f0e-a248-1ae36f8cbb50",
-  "timestamp": "2026-06-28T01:08:49.065486+00:00",
+  "cert_id": "cb09f06e-5cd1-4554-9de1-b59d74df6776",
+  "timestamp": "2026-07-01T01:26:31.554405+00:00",
   "paradata_trail": [],
   "signatures": [
     {


### PR DESCRIPTION
🧹 [test sentient lock cleanup]

🎯 **What:** Hardcoded prefix in test_verify_kinematic_identity_fail dynamically mapped to TAS_KINEMATIC_PREFIX instead.
💡 **Why:** Makes test infrastructure robust to potential future changes to the prefix itself, avoiding brittle mock values.
✅ **Verification:** Pytest suite passes locally.
✨ **Result:** Test maintainability improved.

---
*PR created automatically by Jules for task [1707519380389848730](https://jules.google.com/task/1707519380389848730) started by @TrueAlpha-spiral*