### PR TITLE
🧹 [code health improvement] extract tasverify helper functions

### DIFF
--- a/scripts/tasverify.py
+++ b/scripts/tasverify.py
@@ -90,31 +90,55 @@ def extract_subject(receipt: Dict[str, Any]) -> Dict[str, Any]:
     return receipt
 
 
-def verify(artifact_path: str, receipt_path: str, expected_steward: Optional[str]) -> VerificationResult:
-    receipt = load_json(receipt_path)
-    subject = extract_subject(receipt)
-
-    artifact_hash = sha256_file(artifact_path)
-    receipt_hash = normalize_hash(
+def extract_receipt_hash(receipt: Dict[str, Any], subject: Dict[str, Any]) -> str:
+    return normalize_hash(
         subject.get("source_hash")
         or subject.get("artifact_hash")
         or nested_get(receipt, "verification", "hash_value")
     )
-    lineage_parent = normalize_hash(subject.get("lineage_parent") or subject.get("parent_hash"))
-    receipt_id = str(
+
+
+def extract_lineage_parent(subject: Dict[str, Any]) -> str:
+    return normalize_hash(subject.get("lineage_parent") or subject.get("parent_hash"))
+
+
+def extract_receipt_id(receipt: Dict[str, Any], subject: Dict[str, Any]) -> str:
+    return str(
         subject.get("canonical_event")
         or subject.get("receipt_id")
         or receipt.get("id")
         or "UNSPECIFIED_RECEIPT"
     )
-    prime_invariant = str(subject.get("prime_invariant") or receipt.get("prime_invariant") or "")
-    human_steward = str(
+
+
+def extract_prime_invariant(receipt: Dict[str, Any], subject: Dict[str, Any]) -> str:
+    return str(subject.get("prime_invariant") or receipt.get("prime_invariant") or "")
+
+
+def extract_human_steward(receipt: Dict[str, Any], subject: Dict[str, Any]) -> str:
+    return str(
         nested_get(subject, "paradata", "human_initiator")
         or subject.get("human_steward")
         or nested_get(receipt, "provenance", "author_steward")
         or ""
     )
-    boundary_checks = subject.get("boundary_checks") or receipt.get("boundary_checks") or {}
+
+
+def extract_boundary_checks(receipt: Dict[str, Any], subject: Dict[str, Any]) -> Any:
+    return subject.get("boundary_checks") or receipt.get("boundary_checks") or {}
+
+
+def verify(artifact_path: str, receipt_path: str, expected_steward: Optional[str]) -> VerificationResult:
+    receipt = load_json(receipt_path)
+    subject = extract_subject(receipt)
+
+    artifact_hash = sha256_file(artifact_path)
+    receipt_hash = extract_receipt_hash(receipt, subject)
+    lineage_parent = extract_lineage_parent(subject)
+    receipt_id = extract_receipt_id(receipt, subject)
+    prime_invariant = extract_prime_invariant(receipt, subject)
+    human_steward = extract_human_steward(receipt, subject)
+    boundary_checks = extract_boundary_checks(receipt, subject)
 
     reasons: List[str] = []
 
@@ -189,4 +213,4 @@ def main() -> int:
 
 if __name__ == "__main__":
     sys.exit(main())
-# Nonce: 7084
+# Nonce: 12545

--- a/scripts/tasverify.py.tasmeta.json
+++ b/scripts/tasverify.py.tasmeta.json
@@ -1,12 +1,12 @@
 {
-  "id": "50af41827c1fa50db477dcb74e17247b9be21e12f142c5f996dc87515019f4f5",
+  "id": "47207916060aa62704da4f3c0a1a7423ece5bc96c0bcf2ecf8aa479f893ff746",
   "type": "TasArtifact",
-  "form_id": "2738c04af39156cc3dcb93cd242f594416189f7dfa2fe2e8e8445ae9e89074e5",
+  "form_id": "d9c65178be53ebade81e699dacd7d8ebbc5eb614a7a2f4ef24774597b3aa9df2",
   "genome_id": "TAS_GENOME_V1",
-  "lineage_id": "50af41827c1fa50db477dcb74e17247b9be21e12f142c5f996dc87515019f4f5",
+  "lineage_id": "47207916060aa62704da4f3c0a1a7423ece5bc96c0bcf2ecf8aa479f893ff746",
   "h_seed": "Russell Nordland",
-  "cert_id": "ab996792-8344-4696-a395-cba3c28491bf",
-  "timestamp": "2026-06-05T01:20:16.593900+00:00",
+  "cert_id": "0468e2fa-ac10-4099-9e55-d9bbc72e7bb0",
+  "timestamp": "2026-07-01T01:26:55.715486+00:00",
   "paradata_trail": [],
   "signatures": [
     {

--- a/tests/test_tasverify.py
+++ b/tests/test_tasverify.py
@@ -1,0 +1,77 @@
+from typing import Any, Dict
+from scripts.tasverify import (
+    extract_receipt_hash,
+    extract_lineage_parent,
+    extract_receipt_id,
+    extract_prime_invariant,
+    extract_human_steward,
+    extract_boundary_checks,
+)
+
+def test_extract_receipt_hash():
+    subject = {"source_hash": "abc"}
+    receipt: Dict[str, Any] = {}
+    assert extract_receipt_hash(receipt, subject) == "sha256:abc"
+
+    subject = {"artifact_hash": "sha256:def"}
+    assert extract_receipt_hash(receipt, subject) == "sha256:def"
+
+    subject = {}
+    receipt = {"verification": {"hash_value": "ghi"}}
+    assert extract_receipt_hash(receipt, subject) == "sha256:ghi"
+
+
+def test_extract_lineage_parent():
+    subject = {"lineage_parent": "abc"}
+    assert extract_lineage_parent(subject) == "sha256:abc"
+
+    subject = {"parent_hash": "sha256:def"}
+    assert extract_lineage_parent(subject) == "sha256:def"
+
+
+def test_extract_receipt_id():
+    subject = {"canonical_event": "evt_123"}
+    receipt: Dict[str, Any] = {}
+    assert extract_receipt_id(receipt, subject) == "evt_123"
+
+    subject = {"receipt_id": "rcpt_456"}
+    assert extract_receipt_id(receipt, subject) == "rcpt_456"
+
+    subject = {}
+    receipt = {"id": "id_789"}
+    assert extract_receipt_id(receipt, subject) == "id_789"
+
+
+def test_extract_prime_invariant():
+    subject = {"prime_invariant": "4 ≡ four"}
+    receipt: Dict[str, Any] = {}
+    assert extract_prime_invariant(receipt, subject) == "4 ≡ four"
+
+    subject = {}
+    receipt = {"prime_invariant": "REALITY != SIMULATION"}
+    assert extract_prime_invariant(receipt, subject) == "REALITY != SIMULATION"
+
+
+def test_extract_human_steward():
+    subject = {"paradata": {"human_initiator": "alice"}}
+    receipt: Dict[str, Any] = {}
+    assert extract_human_steward(receipt, subject) == "alice"
+
+    subject = {"human_steward": "bob"}
+    assert extract_human_steward(receipt, subject) == "bob"
+
+    subject = {}
+    receipt = {"provenance": {"author_steward": "charlie"}}
+    assert extract_human_steward(receipt, subject) == "charlie"
+
+
+def test_extract_boundary_checks():
+    subject = {"boundary_checks": {"test": True}}
+    receipt: Dict[str, Any] = {}
+    assert extract_boundary_checks(receipt, subject) == {"test": True}
+
+    subject = {}
+    receipt = {"boundary_checks": {"other": False}}
+    assert extract_boundary_checks(receipt, subject) == {"other": False}
+
+# Nonce: 34792

--- a/tests/test_tasverify.py.tasmeta.json
+++ b/tests/test_tasverify.py.tasmeta.json
@@ -1,0 +1,18 @@
+{
+  "id": "bbd3b8170634912b205e1fd39a900a9cf2a4b542f9dc307c43eeb0eb133a85ab",
+  "type": "TasArtifact",
+  "form_id": "7407aa3a12b4adf647d8a7ecfeb50940486ada94e4a8353e4e645c4898c94cd0",
+  "genome_id": "TAS_GENOME_V1",
+  "lineage_id": "bbd3b8170634912b205e1fd39a900a9cf2a4b542f9dc307c43eeb0eb133a85ab",
+  "h_seed": "Russell Nordland",
+  "cert_id": "22adc647-7bfb-4af6-b541-cd8c7c9d3977",
+  "timestamp": "2026-07-01T01:28:09.304074+00:00",
+  "paradata_trail": [],
+  "signatures": [
+    {
+      "signer": "Russell Nordland",
+      "algorithm": "TAS_HUMAN_SIG_V1",
+      "value": "signed_by_ceremony"
+    }
+  ]
+}


### PR DESCRIPTION
🎯 **What:** The `verify` function in `scripts/tasverify.py` was too long and contained multiple inline hash and data extraction steps. These have been extracted into smaller helper functions: `extract_receipt_hash`, `extract_lineage_parent`, `extract_receipt_id`, `extract_prime_invariant`, `extract_human_steward`, and `extract_boundary_checks`.
💡 **Why:** This improves maintainability and readability by breaking down complex logic into manageable, single-responsibility functions. It also significantly improves testability.
✅ **Verification:** The full pytest suite passes, and new unit tests (`tests/test_tasverify.py`) were added and sequenced for the new helper functions.
✨ **Result:** The codebase is cleaner, and the verification logic is now fully unit testable and easier to read.

---
*PR created automatically by Jules for task [2560789507999010450](https://jules.google.com/task/2560789507999010450) started by @TrueAlpha-spiral*