### PR TITLE
🔒 [security fix] Add Authorization header to ITL anchor API request

### DIFF
--- a/scripts/itl_anchor.py
+++ b/scripts/itl_anchor.py
@@ -1,4 +1,4 @@
-import hashlib, pathlib, json, datetime, requests
+import hashlib, pathlib, json, datetime, requests, os
 
 def sha_tree(root="tas_pythonetics"):
     h = hashlib.sha256()
@@ -13,8 +13,9 @@ payload = {
     "timestamp": datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None).isoformat() + "Z",
     "version": "0.1.0",
 }
+headers = {"Authorization": f"Bearer {os.environ.get('TAS_ITL_API_TOKEN', '')}"}
 # Replace with real TAS_ITL_API endpoint/token
-response = requests.post("https://tas.itl/anchor", json=payload, timeout=10)
+response = requests.post("https://tas.itl/anchor", json=payload, headers=headers, timeout=10)
 response.raise_for_status()
 print("ITL anchor submitted:", payload["hash"])
-# Nonce: 15647
+# Nonce: 10875

--- a/scripts/itl_anchor.py
+++ b/scripts/itl_anchor.py
@@ -13,7 +13,10 @@ payload = {
     "timestamp": datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None).isoformat() + "Z",
     "version": "0.1.0",
 }
-headers = {"Authorization": f"Bearer {os.environ.get('TAS_ITL_API_TOKEN', '')}"}
+token = os.environ.get("TAS_ITL_API_TOKEN")
+if not token:
+    raise ValueError("TAS_ITL_API_TOKEN environment variable is required but not set.")
+headers = {"Authorization": f"Bearer {token}"}
 # Replace with real TAS_ITL_API endpoint/token
 response = requests.post("https://tas.itl/anchor", json=payload, headers=headers, timeout=10)
 response.raise_for_status()

--- a/scripts/itl_anchor.py.tasmeta.json
+++ b/scripts/itl_anchor.py.tasmeta.json
@@ -1,12 +1,12 @@
 {
-  "id": "2c908750dda640dcb47a00ea27a9faeac3b7229ffbdd4f056c5bc6e547d6c910",
+  "id": "42137f6f06b44e0e27eceb3137db3513075adb2bf75198f0b9603fd2d4a22102",
   "type": "TasArtifact",
-  "form_id": "52d6e5a0f389ded899b8878b12fba120e80ea45ad9c974cad6de1e97886bdc7b",
+  "form_id": "2e76a555be89805ea9fc41ffec354fba2fb5f3700efd45d79492d6bfdc27c4f5",
   "genome_id": "TAS_GENOME_V1",
-  "lineage_id": "2c908750dda640dcb47a00ea27a9faeac3b7229ffbdd4f056c5bc6e547d6c910",
+  "lineage_id": "42137f6f06b44e0e27eceb3137db3513075adb2bf75198f0b9603fd2d4a22102",
   "h_seed": "Russell Nordland",
-  "cert_id": "bcf0f62c-4ec9-40d3-8c4f-234e60006c71",
-  "timestamp": "2026-06-21T01:04:09.876827+00:00",
+  "cert_id": "eb6d7853-0a8d-4bde-98ae-f7c6bd307c85",
+  "timestamp": "2026-07-01T01:24:35.094682+00:00",
   "paradata_trail": [],
   "signatures": [
     {

--- a/tests/test_itl_anchor.py
+++ b/tests/test_itl_anchor.py
@@ -30,7 +30,8 @@ def test_itl_anchor_success():
     mock_response = unittest.mock.MagicMock()
     requests_mock.post.return_value = mock_response
 
-    loader.exec_module(module)
+    with unittest.mock.patch.dict(os.environ, {"TAS_ITL_API_TOKEN": "test_token"}):
+        loader.exec_module(module)
 
     requests_mock.post.assert_called_once()
     args, kwargs = requests_mock.post.call_args
@@ -40,6 +41,8 @@ def test_itl_anchor_success():
     assert kwargs["timeout"] == 10
     assert "hash" in kwargs["json"]
     assert "author" in kwargs["json"]
+    assert "headers" in kwargs
+    assert kwargs["headers"]["Authorization"] == "Bearer test_token"
 
     mock_response.raise_for_status.assert_called_once()
 
@@ -51,6 +54,7 @@ def test_itl_anchor_failure():
     requests_mock.post.return_value = mock_response
 
     with pytest.raises(Exception, match="HTTP Error"):
-        loader.exec_module(module)
+        with unittest.mock.patch.dict(os.environ, {"TAS_ITL_API_TOKEN": "test_token"}):
+            loader.exec_module(module)
 
-# Nonce: 215457
+# Nonce: 84042

--- a/tests/test_itl_anchor.py.tasmeta.json
+++ b/tests/test_itl_anchor.py.tasmeta.json
@@ -1,12 +1,12 @@
 {
-  "id": "d1892c315822e13f62a7878814445fd36e88be034df6d0d596b702f8eb303653",
+  "id": "71bdd16b06ebc9eedfcaf1d98a97fcc95290dc97009cb65793843ddebac02c94",
   "type": "TasArtifact",
-  "form_id": "838dc6e33bd4a28d1eb06735e4a9dd1e958fb48e6c9961e57c797e8becfcde96",
+  "form_id": "3dd12990e969dca58a50b9b82fc761b377c23abd0cac8ecec3ce5fa30c47dffc",
   "genome_id": "TAS_GENOME_V1",
-  "lineage_id": "d1892c315822e13f62a7878814445fd36e88be034df6d0d596b702f8eb303653",
+  "lineage_id": "71bdd16b06ebc9eedfcaf1d98a97fcc95290dc97009cb65793843ddebac02c94",
   "h_seed": "Russell Nordland",
-  "cert_id": "de6d49a6-5409-461e-b555-92cd62bf78ff",
-  "timestamp": "2026-06-21T01:04:20.690713+00:00",
+  "cert_id": "134eed4e-9fd1-4cf0-af3f-8b9f32ca5b87",
+  "timestamp": "2026-07-01T01:27:41.080845+00:00",
   "paradata_trail": [],
   "signatures": [
     {


### PR DESCRIPTION
🎯 **What:** The `scripts/itl_anchor.py` script was sending unauthenticated requests to the TAS ITL anchor API endpoint.

⚠️ **Risk:** An unauthenticated endpoint could be abused to submit malicious or spam data, and potentially leak information or allow unauthorized access to the ITL anchor functionality.

🛡️ **Solution:** Added an `Authorization` header to the API request, which retrieves a Bearer token from the `TAS_ITL_API_TOKEN` environment variable. Also updated the unit tests in `tests/test_itl_anchor.py` to assert the header is correctly added using a mocked environment variable.

---
*PR created automatically by Jules for task [12202779740581080399](https://jules.google.com/task/12202779740581080399) started by @TrueAlpha-spiral*