### PR TITLE
🔄 [metadata sync] Update kinematic identity for test_sentient_lock.py

### DIFF
--- a/tas_pythonetics/tests/test_sentient_lock.py
+++ b/tas_pythonetics/tests/test_sentient_lock.py
@@ -108,4 +108,4 @@ class TestSentientLock(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
-# Nonce: 8349
+# Nonce: 166897

--- a/tas_pythonetics/tests/test_sentient_lock.py.tasmeta.json
+++ b/tas_pythonetics/tests/test_sentient_lock.py.tasmeta.json
@@ -1,12 +1,12 @@
 {
-  "id": "d39b03c2fe3223bb306197f163fd9c1a2880149f34f3cf1bb097287189dba771",
+  "id": "1cf6546ec4f925789b5842aae5065a3b9e1dc0c1a981b53c350d462bed2dd6ec",
   "type": "TasArtifact",
-  "form_id": "1b9c100267b4b5723a0cdff37d1191efaad1bb5e52d51f09c7e1b03fc524f728",
+  "form_id": "9f9f14a31867b97598183cda24bc5caec613301b10853de9feb3a462df459dcd",
   "genome_id": "TAS_GENOME_V1",
-  "lineage_id": "d39b03c2fe3223bb306197f163fd9c1a2880149f34f3cf1bb097287189dba771",
+  "lineage_id": "1cf6546ec4f925789b5842aae5065a3b9e1dc0c1a981b53c350d462bed2dd6ec",
   "h_seed": "Russell Nordland",
-  "cert_id": "0cfa4391-85f1-4b7d-acb1-57064c36d306",
-  "timestamp": "2026-07-01T01:25:04.326327+00:00",
+  "cert_id": "d804127c-6318-4270-9d81-bc5a9319b41a",
+  "timestamp": "2026-07-02T01:10:07.504420+00:00",
   "paradata_trail": [],
   "signatures": [
     {


### PR DESCRIPTION
🎯 **What:** Update the kinematic identity and nonce for the drifted artifact `tas_pythonetics/tests/test_sentient_lock.py` via the TrueAlphaSpiral trigger.
💡 **Why:** Resolves Form ID mismatches causing the unsequenced / drifted artifact error reported by `shadow-scan`.
✅ **Verification:** Ran tests and `shadow-scan` to verify state integrity and that there are no regressions.
✨ **Result:** Living Braid verified artifacts increased to 156 with 0 noise/drifted artifacts.

---
*PR created automatically by Jules for task [14856885489585461445](https://jules.google.com/task/14856885489585461445) started by @TrueAlpha-spiral*