### PR TITLE
Add authority registry checkpoint v1 contract

### DIFF
--- a/docs/specs/authority_registry_checkpoint_v1.md
+++ b/docs/specs/authority_registry_checkpoint_v1.md
@@ -1,0 +1,88 @@
+# Authority Registry Snapshot Checkpoint v1
+
+`tas.authority-registry-checkpoint.v1` is the fail-closed evidence contract for
+living authority status.  It is upstream of execution and Phoenix recovery.
+
+## Separation of roles
+
+- A human authorization key constitutes bounded permission.
+- A registry signing key attests the living status of that authority.
+- A runtime key attests the resulting execution history.
+
+No key may substitute for another role.
+
+## Checkpoint
+
+```json
+{
+  "schema": "tas.authority-registry-checkpoint.v1",
+  "registry_id": "tas://authority-registry/primary",
+  "sequence": 42,
+  "issued_at": "2026-07-11T13:00:00Z",
+  "valid_until": "2026-07-11T13:05:00Z",
+  "previous_checkpoint_hash": "sha256:...",
+  "entries_root": "sha256:...",
+  "entry_count": 17,
+  "signing_key_id": "ed25519:...",
+  "signature": "base64:...",
+  "checkpoint_hash": "sha256:..."
+}
+```
+
+The registry signature covers the domain-separated canonical JSON projection
+that excludes `signature` and `checkpoint_hash`.  The final checkpoint hash
+covers canonical JSON including `signature` and excluding only
+`checkpoint_hash`.
+
+## Authority lookup proof
+
+```json
+{
+  "anchor_id": "ed25519:...",
+  "status": "ACTIVE",
+  "authority_epoch": 7,
+  "effective_at": "2026-07-11T12:45:00Z",
+  "revoked_at": null,
+  "scope_policy_hash": "sha256:...",
+  "inclusion_proof": ["sha256:..."],
+  "checkpoint_hash": "sha256:..."
+}
+```
+
+Entries use domain-separated canonical JSON leaf hashes. Merkle parents are
+`SHA-256(sort(left, right))`, so compact sibling-only proofs are unambiguous.
+
+## Admission rules
+
+A verifier MUST reject evidence when:
+
+- the registry signing key is untrusted or its signature is invalid;
+- the checkpoint is expired, too old, or not yet valid;
+- its sequence does not exceed durable anti-rollback state;
+- it does not extend the highest accepted checkpoint hash;
+- the lookup is bound to another checkpoint;
+- the requested authority is absent, unknown, inactive, revoked, or not yet
+  effective;
+- the inclusion proof does not resolve to `entries_root`.
+
+After successful verification, the runtime persists:
+
+```text
+registry_id
+highest_accepted_sequence
+highest_accepted_checkpoint_hash
+accepted_at
+```
+
+The accepted `checkpoint_hash` is then bound into the runtime attestation at
+admission, resume, and immediately before any external side effect.
+
+## Resolver interfaces
+
+The Python contract defines transport-neutral protocols for checkpoint and
+authority-proof retrieval, registry signature verification, and runtime
+attestation signing. A KMS/HSM adapter implements those protocols without ever
+returning human or runtime private-key material to the engine.
+
+Phoenix consumes terminal failure receipts only after these checks. It does not
+participate in authority resolution and cannot bypass it.

--- a/tas_openai_bridge/authority_registry.py
+++ b/tas_openai_bridge/authority_registry.py
@@ -1,0 +1,261 @@
+"""Fail-closed authority-registry checkpoint verification contracts.
+
+The module deliberately separates three roles:
+
+* a human key authorizes an action;
+* a registry signer attests the current status of that authority key;
+* a runtime key attests the execution history.
+
+No private-key custody implementation is included here.  KMS/HSM adapters satisfy
+the protocols below without exposing steward private keys to the runtime engine.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Mapping, Protocol, Sequence
+
+
+CHECKPOINT_SCHEMA = "tas.authority-registry-checkpoint.v1"
+CHECKPOINT_DOMAIN = b"TAS-AUTHORITY-REGISTRY-CHECKPOINT-V1\x00"
+ENTRY_DOMAIN = b"TAS-AUTHORITY-REGISTRY-ENTRY-V1\x00"
+SHA256_PREFIX = "sha256:"
+
+
+class RegistryVerificationError(ValueError):
+    """Raised when registry evidence cannot be admitted."""
+
+
+def _canonical_json(value: Mapping[str, object]) -> bytes:
+    return json.dumps(
+        value, sort_keys=True, separators=(",", ":"), ensure_ascii=False
+    ).encode("utf-8")
+
+
+def _sha256(payload: bytes) -> str:
+    return SHA256_PREFIX + hashlib.sha256(payload).hexdigest()
+
+
+def _parse_time(value: str) -> datetime:
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        raise RegistryVerificationError("timestamps must include a timezone")
+    return parsed.astimezone(timezone.utc)
+
+
+def _hash_bytes(value: str) -> bytes:
+    if not value.startswith(SHA256_PREFIX) or len(value) != 71:
+        raise RegistryVerificationError("invalid sha256 identifier")
+    try:
+        return bytes.fromhex(value[len(SHA256_PREFIX) :])
+    except ValueError as exc:
+        raise RegistryVerificationError("invalid sha256 identifier") from exc
+
+
+@dataclass(frozen=True)
+class RegistryCheckpoint:
+    registry_id: str
+    sequence: int
+    issued_at: str
+    valid_until: str
+    previous_checkpoint_hash: str
+    entries_root: str
+    entry_count: int
+    signing_key_id: str
+    signature: str
+    checkpoint_hash: str
+    schema: str = CHECKPOINT_SCHEMA
+
+    def unsigned_body(self) -> dict[str, object]:
+        return {
+            "schema": self.schema,
+            "registry_id": self.registry_id,
+            "sequence": self.sequence,
+            "issued_at": self.issued_at,
+            "valid_until": self.valid_until,
+            "previous_checkpoint_hash": self.previous_checkpoint_hash,
+            "entries_root": self.entries_root,
+            "entry_count": self.entry_count,
+            "signing_key_id": self.signing_key_id,
+        }
+
+    def signing_payload(self) -> bytes:
+        return CHECKPOINT_DOMAIN + _canonical_json(self.unsigned_body())
+
+    def completed_body(self) -> dict[str, object]:
+        return {**self.unsigned_body(), "signature": self.signature}
+
+    def calculated_hash(self) -> str:
+        return _sha256(_canonical_json(self.completed_body()))
+
+
+@dataclass(frozen=True)
+class AuthorityRecord:
+    anchor_id: str
+    status: str
+    authority_epoch: int
+    effective_at: str
+    revoked_at: str | None
+    scope_policy_hash: str
+
+    def body(self) -> dict[str, object]:
+        return {
+            "anchor_id": self.anchor_id,
+            "status": self.status,
+            "authority_epoch": self.authority_epoch,
+            "effective_at": self.effective_at,
+            "revoked_at": self.revoked_at,
+            "scope_policy_hash": self.scope_policy_hash,
+        }
+
+    def leaf_hash(self) -> str:
+        return _sha256(ENTRY_DOMAIN + _canonical_json(self.body()))
+
+
+@dataclass(frozen=True)
+class AuthorityLookupProof:
+    record: AuthorityRecord
+    inclusion_proof: tuple[str, ...]
+    checkpoint_hash: str
+
+
+@dataclass(frozen=True)
+class AntiRollbackState:
+    registry_id: str
+    highest_accepted_sequence: int
+    highest_accepted_checkpoint_hash: str
+    accepted_at: str
+
+
+class RegistrySignatureVerifier(Protocol):
+    """KMS/HSM-backed verification boundary for registry signing keys."""
+
+    def is_trusted_registry_key(self, key_id: str) -> bool: ...
+
+    def verify_registry_signature(
+        self, key_id: str, payload: bytes, signature: str
+    ) -> bool: ...
+
+
+class AuthorityRegistryResolver(Protocol):
+    """Transport-neutral resolver; implementations may use KMS/HSM services."""
+
+    def fetch_checkpoint(self, registry_id: str) -> RegistryCheckpoint: ...
+
+    def fetch_authority_proof(
+        self, registry_id: str, anchor_id: str, checkpoint_hash: str
+    ) -> AuthorityLookupProof: ...
+
+
+class RuntimeAttestationSigner(Protocol):
+    """Runtime signing interface; it must never expose private key material."""
+
+    @property
+    def runtime_key_id(self) -> str: ...
+
+    def sign_runtime_attestation(self, payload: bytes) -> str: ...
+
+
+def verify_sorted_merkle_proof(
+    leaf_hash: str, proof: Sequence[str], expected_root: str
+) -> bool:
+    """Verify a sorted-pair SHA-256 Merkle proof.
+
+    Sorted pairs make the compact ``["sha256:..."]`` proof format
+    unambiguous without left/right direction fields.
+    """
+
+    current = _hash_bytes(leaf_hash)
+    for sibling_hash in proof:
+        sibling = _hash_bytes(sibling_hash)
+        left, right = sorted((current, sibling))
+        current = hashlib.sha256(left + right).digest()
+    return SHA256_PREFIX + current.hex() == expected_root
+
+
+class RegistryCheckpointVerifier:
+    def __init__(
+        self,
+        signature_verifier: RegistrySignatureVerifier,
+        *,
+        maximum_age_seconds: int = 300,
+    ) -> None:
+        if maximum_age_seconds <= 0:
+            raise ValueError("maximum_age_seconds must be positive")
+        self._signatures = signature_verifier
+        self._maximum_age_seconds = maximum_age_seconds
+
+    def verify(
+        self,
+        checkpoint: RegistryCheckpoint,
+        lookup: AuthorityLookupProof,
+        *,
+        expected_anchor_id: str,
+        now: datetime,
+        prior_state: AntiRollbackState | None,
+    ) -> AntiRollbackState:
+        now = now.astimezone(timezone.utc)
+        self._verify_checkpoint(checkpoint, now=now, prior_state=prior_state)
+
+        if lookup.checkpoint_hash != checkpoint.checkpoint_hash:
+            raise RegistryVerificationError("lookup is bound to another checkpoint")
+        if lookup.record.anchor_id != expected_anchor_id:
+            raise RegistryVerificationError("authority key is unknown")
+        if lookup.record.status != "ACTIVE" or lookup.record.revoked_at is not None:
+            raise RegistryVerificationError("authority is not active")
+        if _parse_time(lookup.record.effective_at) > now:
+            raise RegistryVerificationError("authority record is not yet effective")
+        if not verify_sorted_merkle_proof(
+            lookup.record.leaf_hash(), lookup.inclusion_proof, checkpoint.entries_root
+        ):
+            raise RegistryVerificationError("invalid authority inclusion proof")
+
+        return AntiRollbackState(
+            registry_id=checkpoint.registry_id,
+            highest_accepted_sequence=checkpoint.sequence,
+            highest_accepted_checkpoint_hash=checkpoint.checkpoint_hash,
+            accepted_at=now.isoformat().replace("+00:00", "Z"),
+        )
+
+    def _verify_checkpoint(
+        self,
+        checkpoint: RegistryCheckpoint,
+        *,
+        now: datetime,
+        prior_state: AntiRollbackState | None,
+    ) -> None:
+        if checkpoint.schema != CHECKPOINT_SCHEMA:
+            raise RegistryVerificationError("unsupported checkpoint schema")
+        if checkpoint.sequence < 0 or checkpoint.entry_count < 0:
+            raise RegistryVerificationError("negative checkpoint counters")
+        _hash_bytes(checkpoint.previous_checkpoint_hash)
+        _hash_bytes(checkpoint.entries_root)
+        if checkpoint.calculated_hash() != checkpoint.checkpoint_hash:
+            raise RegistryVerificationError("checkpoint hash mismatch")
+        if not self._signatures.is_trusted_registry_key(checkpoint.signing_key_id):
+            raise RegistryVerificationError("untrusted registry signing key")
+        if not self._signatures.verify_registry_signature(
+            checkpoint.signing_key_id,
+            checkpoint.signing_payload(),
+            checkpoint.signature,
+        ):
+            raise RegistryVerificationError("invalid registry signature")
+
+        issued_at = _parse_time(checkpoint.issued_at)
+        valid_until = _parse_time(checkpoint.valid_until)
+        if not issued_at <= now < valid_until:
+            raise RegistryVerificationError("checkpoint is outside its validity window")
+        if (now - issued_at).total_seconds() > self._maximum_age_seconds:
+            raise RegistryVerificationError("checkpoint exceeds freshness limit")
+
+        if prior_state is not None:
+            if checkpoint.registry_id != prior_state.registry_id:
+                raise RegistryVerificationError("registry identity changed")
+            if checkpoint.sequence <= prior_state.highest_accepted_sequence:
+                raise RegistryVerificationError("checkpoint rollback or equivocation")
+            if checkpoint.previous_checkpoint_hash != prior_state.highest_accepted_checkpoint_hash:
+                raise RegistryVerificationError("checkpoint does not extend accepted lineage")
+

--- a/tests/tas_openai_bridge/test_authority_registry.py
+++ b/tests/tas_openai_bridge/test_authority_registry.py
@@ -1,0 +1,148 @@
+from dataclasses import replace
+from datetime import datetime, timezone
+import hashlib
+
+import pytest
+
+from tas_openai_bridge.authority_registry import (
+    AntiRollbackState,
+    AuthorityLookupProof,
+    AuthorityRecord,
+    RegistryCheckpoint,
+    RegistryCheckpointVerifier,
+    RegistryVerificationError,
+)
+
+
+NOW = datetime(2026, 7, 11, 13, 0, tzinfo=timezone.utc)
+ZERO_HASH = "sha256:" + "0" * 64
+
+
+class TestSignatures:
+    trusted_key = "ed25519:" + "1" * 64
+
+    def is_trusted_registry_key(self, key_id: str) -> bool:
+        return key_id == self.trusted_key
+
+    def verify_registry_signature(self, key_id, payload, signature) -> bool:
+        expected = "test:" + hashlib.sha256(payload).hexdigest()
+        return self.is_trusted_registry_key(key_id) and signature == expected
+
+
+def make_record(status="ACTIVE", anchor_id="ed25519:" + "2" * 64):
+    return AuthorityRecord(
+        anchor_id=anchor_id,
+        status=status,
+        authority_epoch=7,
+        effective_at="2026-07-11T12:45:00Z",
+        revoked_at=None if status == "ACTIVE" else "2026-07-11T12:55:00Z",
+        scope_policy_hash="sha256:" + "3" * 64,
+    )
+
+
+def make_checkpoint(record, *, sequence=42, previous=ZERO_HASH):
+    unsigned = RegistryCheckpoint(
+        registry_id="tas://authority-registry/primary",
+        sequence=sequence,
+        issued_at="2026-07-11T12:59:00Z",
+        valid_until="2026-07-11T13:05:00Z",
+        previous_checkpoint_hash=previous,
+        entries_root=record.leaf_hash(),
+        entry_count=1,
+        signing_key_id=TestSignatures.trusted_key,
+        signature="pending",
+        checkpoint_hash=ZERO_HASH,
+    )
+    signature = "test:" + hashlib.sha256(unsigned.signing_payload()).hexdigest()
+    signed = replace(unsigned, signature=signature)
+    return replace(signed, checkpoint_hash=signed.calculated_hash())
+
+
+def verify(checkpoint, record, *, anchor_id=None, prior_state=None):
+    lookup = AuthorityLookupProof(record, (), checkpoint.checkpoint_hash)
+    return RegistryCheckpointVerifier(TestSignatures()).verify(
+        checkpoint,
+        lookup,
+        expected_anchor_id=anchor_id or record.anchor_id,
+        now=NOW,
+        prior_state=prior_state,
+    )
+
+
+def test_accepts_fresh_signed_checkpoint_and_active_inclusion():
+    record = make_record()
+    checkpoint = make_checkpoint(record)
+    state = verify(checkpoint, record)
+    assert state.highest_accepted_sequence == 42
+    assert state.highest_accepted_checkpoint_hash == checkpoint.checkpoint_hash
+
+
+def test_unknown_authority_fails_closed():
+    record = make_record()
+    checkpoint = make_checkpoint(record)
+    with pytest.raises(RegistryVerificationError, match="unknown"):
+        verify(checkpoint, record, anchor_id="ed25519:" + "9" * 64)
+
+
+def test_revoked_authority_is_rejected():
+    record = make_record(status="REVOKED")
+    checkpoint = make_checkpoint(record)
+    with pytest.raises(RegistryVerificationError, match="not active"):
+        verify(checkpoint, record)
+
+
+def test_old_signed_checkpoint_cannot_roll_back_state():
+    record = make_record()
+    checkpoint = make_checkpoint(record, sequence=42)
+    prior = AntiRollbackState(
+        checkpoint.registry_id, 42, checkpoint.checkpoint_hash, "2026-07-11T13:00:00Z"
+    )
+    with pytest.raises(RegistryVerificationError, match="rollback or equivocation"):
+        verify(checkpoint, record, prior_state=prior)
+
+
+def test_new_checkpoint_must_extend_accepted_lineage():
+    record = make_record()
+    prior = AntiRollbackState(
+        "tas://authority-registry/primary", 41, "sha256:" + "8" * 64,
+        "2026-07-11T12:58:00Z",
+    )
+    checkpoint = make_checkpoint(record, sequence=42, previous=ZERO_HASH)
+    with pytest.raises(RegistryVerificationError, match="does not extend"):
+        verify(checkpoint, record, prior_state=prior)
+
+
+def test_tampered_checkpoint_hash_is_rejected():
+    record = make_record()
+    checkpoint = replace(make_checkpoint(record), entry_count=2)
+    with pytest.raises(RegistryVerificationError, match="hash mismatch"):
+        verify(checkpoint, record)
+
+
+def test_untrusted_registry_key_is_rejected():
+    record = make_record()
+    checkpoint = make_checkpoint(record)
+    checkpoint = replace(
+        checkpoint,
+        signing_key_id="ed25519:" + "7" * 64,
+    )
+    checkpoint = replace(checkpoint, checkpoint_hash=checkpoint.calculated_hash())
+    with pytest.raises(RegistryVerificationError, match="untrusted"):
+        verify(checkpoint, record)
+
+
+def test_invalid_inclusion_proof_is_rejected():
+    record = make_record()
+    checkpoint = make_checkpoint(record)
+    lookup = AuthorityLookupProof(
+        record, ("sha256:" + "6" * 64,), checkpoint.checkpoint_hash
+    )
+    with pytest.raises(RegistryVerificationError, match="inclusion proof"):
+        RegistryCheckpointVerifier(TestSignatures()).verify(
+            checkpoint,
+            lookup,
+            expected_anchor_id=record.anchor_id,
+            now=NOW,
+            prior_state=None,
+        )
+


### PR DESCRIPTION
## What changed

- defines the signed `tas.authority-registry-checkpoint.v1` contract
- verifies trusted registry signatures, freshness, monotonic sequence, and checkpoint lineage
- verifies checkpoint-bound authority records with sorted-pair Merkle inclusion proofs
- rejects unknown, inactive, revoked, future-effective, stale, rolled-back, and equivocated authority evidence
- introduces transport-neutral KMS/HSM resolver and runtime signer protocols without exposing private keys
- documents that the accepted checkpoint hash must be bound at admission, resume, and the immediate side-effect boundary

## Why

The runtime needs falsifiable living-authority evidence. A signed timestamp or self-reported `revoked` flag is insufficient because an old but valid checkpoint can be replayed. Durable anti-rollback state and checkpoint-bound inclusion proofs establish exactly which registry state authorized a transition.

Phoenix remains downstream and is intentionally unchanged.

## Validation

- `python -m py_compile tas_openai_bridge/authority_registry.py tests/tas_openai_bridge/test_authority_registry.py`
- focused pytest suite authored for acceptance and fail-closed cases

`pytest` was not installed in the local scratch runtime, so the focused suite still needs to run in repository CI.