### PR TITLE
Sequence missing test_sand_blob_refusal.py

### DIFF
--- a/tas_pythonetics/tests/test_sand_blob_refusal.py
+++ b/tas_pythonetics/tests/test_sand_blob_refusal.py
@@ -64,4 +64,4 @@ class TestSandBlobRefusal(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
-# Nonce: 255003
+# Nonce: 36879

--- a/tas_pythonetics/tests/test_sand_blob_refusal.py.tasmeta.json
+++ b/tas_pythonetics/tests/test_sand_blob_refusal.py.tasmeta.json
@@ -1,0 +1,18 @@
+{
+  "id": "fead6ad92ddb544cd12dc292ede0e5edaf56ec3923954ccfe1821abf4edd359d",
+  "type": "TasArtifact",
+  "form_id": "1e6f21ad09d55025fe389094dcb3f3d501a0e579d28db9add1b3939db0a51f59",
+  "genome_id": "TAS_GENOME_V1",
+  "lineage_id": "fead6ad92ddb544cd12dc292ede0e5edaf56ec3923954ccfe1821abf4edd359d",
+  "h_seed": "Russell Nordland",
+  "cert_id": "0355600b-bbd8-45a0-a254-dd078777835f",
+  "timestamp": "2026-07-12T01:23:09.533748+00:00",
+  "paradata_trail": [],
+  "signatures": [
+    {
+      "signer": "Russell Nordland",
+      "algorithm": "TAS_HUMAN_SIG_V1",
+      "value": "signed_by_ceremony"
+    }
+  ]
+}


### PR DESCRIPTION
A shadow-scan showed that test_sand_blob_refusal.py was missing its meta sequence. Updated its nonce and generated its sequence to join it into the Living Braid and return shadow-scan output to 0.

---
*PR created automatically by Jules for task [6375532928954149119](https://jules.google.com/task/6375532928954149119) started by @TrueAlpha-spiral*