### PR TITLE
Add registry checkpointing, governance runtime ledger, and KMS test resolvers with tests

### DIFF
--- a/tas_openai_bridge/__init__.py
+++ b/tas_openai_bridge/__init__.py
@@ -17,7 +17,15 @@ from .governance_runtime import (
     audit_event,
     runtime_attestation_body,
 )
-from .kms import HMACKeyResolver, HumanAuthorizationResolver, RuntimeKeyResolver
+from .kms import (
+    DEFAULT_CANONICALIZATION_VERSION,
+    HUMAN_AUTHORIZATION_DOMAIN,
+    HMACKeyResolver,
+    HumanAuthorizationResolver,
+    RuntimeKeyResolver,
+    human_authorization_message,
+    verify_human_authorization_envelope,
+)
 from .registry_checkpoint import (
     AntiRollbackState,
     AuthorityLookupProof,
@@ -59,6 +67,8 @@ __all__ = [
     "AntiRollbackState",
     "AuthorityLookupProof",
     "GovernanceRuntimeLedger",
+    "DEFAULT_CANONICALIZATION_VERSION",
+    "HUMAN_AUTHORIZATION_DOMAIN",
     "HMACKeyResolver",
     "HumanAuthorizationResolver",
     "InMemoryRegistrySigningKeyResolver",
@@ -66,9 +76,11 @@ __all__ = [
     "RegistryVerificationError",
     "RuntimeKeyResolver",
     "accept_authority_lookup",
+    "human_authorization_message",
     "audit_event",
     "build_checkpoint",
     "runtime_attestation_body",
+    "verify_human_authorization_envelope",
     "tas_openai_execute",
 ]
 # Nonce: 120693

--- a/tas_openai_bridge/__init__.py
+++ b/tas_openai_bridge/__init__.py
@@ -11,6 +11,22 @@ from .receipts import ProvenanceReceipt
 from .refusal import RefusalArtifact
 from .schemas import TAS_CANDIDATE_RESPONSE_SCHEMA, CandidateResponse
 from .authority import HumanAPIKey, ScopedAuthority
+
+from .governance_runtime import (
+    GovernanceRuntimeLedger,
+    audit_event,
+    runtime_attestation_body,
+)
+from .kms import HMACKeyResolver, HumanAuthorizationResolver, RuntimeKeyResolver
+from .registry_checkpoint import (
+    AntiRollbackState,
+    AuthorityLookupProof,
+    InMemoryRegistrySigningKeyResolver,
+    RegistryCheckpoint,
+    RegistryVerificationError,
+    accept_authority_lookup,
+    build_checkpoint,
+)
 from .trinity import (
     ArchetypeAnalysis,
     OctopusArchetype,
@@ -40,6 +56,19 @@ __all__ = [
     "TrinityResult",
     "ArchetypeAnalysis",
     "tas_admissibility_gateway",
+    "AntiRollbackState",
+    "AuthorityLookupProof",
+    "GovernanceRuntimeLedger",
+    "HMACKeyResolver",
+    "HumanAuthorizationResolver",
+    "InMemoryRegistrySigningKeyResolver",
+    "RegistryCheckpoint",
+    "RegistryVerificationError",
+    "RuntimeKeyResolver",
+    "accept_authority_lookup",
+    "audit_event",
+    "build_checkpoint",
+    "runtime_attestation_body",
     "tas_openai_execute",
 ]
 # Nonce: 120693

--- a/tas_openai_bridge/governance_runtime.py
+++ b/tas_openai_bridge/governance_runtime.py
@@ -1,0 +1,113 @@
+"""Hash-linked governance runtime events with explicit attestation projection."""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+from typing import Any
+
+from .kms import RuntimeKeyResolver
+from .registry_checkpoint import canonicalize, canonical_hash
+
+DOMAIN = b"TAS-RUNTIME-V2"
+VALID_STATES = {"PAUSED", "COMMIT_AUTHORIZED", "EXECUTING", "CANCELLED"}
+VALID_EVENT_TYPES = {"RESUME_DECISION", "EXECUTION_STARTED", "COMMIT_CANCELLED"}
+VALID_TRANSITIONS = {
+    ("PAUSED", "RESUME_DECISION", "COMMIT_AUTHORIZED"),
+    ("COMMIT_AUTHORIZED", "EXECUTION_STARTED", "EXECUTING"),
+    ("COMMIT_AUTHORIZED", "COMMIT_CANCELLED", "CANCELLED"),
+}
+
+
+def runtime_attestation_body(event: dict[str, Any]) -> dict[str, Any]:
+    body = copy.deepcopy(event)
+    body.pop("event_hash", None)
+    body["runtime_attestation"]["runtime_signature"] = None
+    return body
+
+
+def runtime_signing_message(event: dict[str, Any], previous_hash: str) -> bytes:
+    attestation = event["runtime_attestation"]
+    digest = hashlib.sha256(canonicalize(runtime_attestation_body(event))).hexdigest()
+    fields = [
+        DOMAIN.decode(),
+        previous_hash,
+        "sha256:" + digest,
+        event["decision"].get("state", ""),
+        attestation["lease_id"],
+        str(attestation["lease_usage_count"]),
+        attestation["registry_checkpoint_hash"],
+    ]
+    return "|".join(fields).encode()
+
+
+def final_event_hash(event: dict[str, Any]) -> str:
+    body = copy.deepcopy(event)
+    body.pop("event_hash", None)
+    return canonical_hash(body)
+
+
+class GovernanceRuntimeLedger:
+    def __init__(self, runtime_resolver: RuntimeKeyResolver, runtime_key_id: str):
+        if not runtime_resolver.is_trusted_runtime_key(runtime_key_id):
+            raise ValueError("Runtime key is not trusted")
+        self.runtime_resolver = runtime_resolver
+        self.runtime_key_id = runtime_key_id
+        self.current_state = "PAUSED"
+        self.previous_hash = "sha256:genesis"
+        self.events: list[dict[str, Any]] = []
+
+    def commit_transition(
+        self,
+        *,
+        event_type: str,
+        next_state: str,
+        decision: dict[str, Any],
+        lease_id: str,
+        lease_usage_count: int,
+        registry_checkpoint_hash: str,
+    ) -> dict[str, Any]:
+        if next_state not in VALID_STATES:
+            raise ValueError("Invalid resulting state")
+        if event_type not in VALID_EVENT_TYPES:
+            raise ValueError("Invalid event type")
+        if (self.current_state, event_type, next_state) not in VALID_TRANSITIONS:
+            raise ValueError("Invalid governance transition")
+        event = {
+            "event_type": event_type,
+            "previous_state": self.current_state,
+            "decision": {**decision, "state": next_state},
+            "runtime_attestation": {
+                "runtime_key_id": self.runtime_key_id,
+                "lease_id": lease_id,
+                "lease_usage_count": lease_usage_count,
+                "registry_checkpoint_hash": registry_checkpoint_hash,
+                "runtime_signature": None,
+            },
+            "previous_hash": self.previous_hash,
+        }
+        message = runtime_signing_message(event, self.previous_hash)
+        event["runtime_attestation"]["runtime_signature"] = self.runtime_resolver.sign_runtime(
+            self.runtime_key_id, message
+        )
+        event["event_hash"] = final_event_hash(event)
+        self.events.append(event)
+        self.previous_hash = event["event_hash"]
+        self.current_state = next_state
+        return event
+
+
+def audit_event(event: dict[str, Any], resolver: RuntimeKeyResolver) -> None:
+    if event["decision"]["state"] not in VALID_STATES:
+        raise ValueError("Invalid audited state")
+    transition = (event["previous_state"], event["event_type"], event["decision"]["state"])
+    if transition not in VALID_TRANSITIONS:
+        raise ValueError("Invalid audited transition")
+    attestation = event["runtime_attestation"]
+    if not resolver.is_trusted_runtime_key(attestation["runtime_key_id"]):
+        raise ValueError("Untrusted runtime key")
+    message = runtime_signing_message(event, event["previous_hash"])
+    if not resolver.verify_runtime(attestation["runtime_key_id"], message, attestation["runtime_signature"]):
+        raise ValueError("Invalid runtime signature")
+    if event["event_hash"] != final_event_hash(event):
+        raise ValueError("Invalid final event hash")

--- a/tas_openai_bridge/kms.py
+++ b/tas_openai_bridge/kms.py
@@ -5,7 +5,68 @@ from __future__ import annotations
 from dataclasses import dataclass
 import hashlib
 import hmac
-from typing import Protocol
+import json
+from typing import Any, Protocol
+
+HUMAN_AUTHORIZATION_DOMAIN = "TAS-HUMAN-AUTHORIZATION-V1"
+DEFAULT_CANONICALIZATION_VERSION = "tas-canonical-json-v1"
+
+
+def human_authorization_message(
+    *,
+    credential_id: str,
+    candidate_hash: str,
+    requested_operation: str,
+    canonicalization_version: str = DEFAULT_CANONICALIZATION_VERSION,
+    domain: str = HUMAN_AUTHORIZATION_DOMAIN,
+    context: dict[str, Any] | None = None,
+) -> bytes:
+    """Build the steward authorization envelope bytes signed outside the runtime.
+
+    The envelope binds who authorized, exactly what candidate was authorized, which
+    operation was requested, and the canonicalization/domain version used to
+    interpret the signed payload. The runtime may verify this message through a
+    resolver, but it never receives steward private key material.
+    """
+
+    required = {
+        "domain": domain,
+        "credential_id": credential_id,
+        "candidate_hash": candidate_hash,
+        "requested_operation": requested_operation,
+        "canonicalization_version": canonicalization_version,
+    }
+    for field_name, value in required.items():
+        if not isinstance(value, str) or not value.strip():
+            raise ValueError(f"{field_name} is required for human authorization")
+    payload = {**required, "context": context or {}}
+    return json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+
+
+def verify_human_authorization_envelope(
+    resolver: "HumanAuthorizationResolver",
+    *,
+    credential_id: str,
+    candidate_hash: str,
+    requested_operation: str,
+    signature: str,
+    canonicalization_version: str = DEFAULT_CANONICALIZATION_VERSION,
+    domain: str = HUMAN_AUTHORIZATION_DOMAIN,
+    context: dict[str, Any] | None = None,
+) -> bool:
+    """Verify a domain-separated steward envelope with fail-closed key lookup."""
+
+    if resolver is None or not resolver.is_known_authority(credential_id):
+        return False
+    message = human_authorization_message(
+        credential_id=credential_id,
+        candidate_hash=candidate_hash,
+        requested_operation=requested_operation,
+        canonicalization_version=canonicalization_version,
+        domain=domain,
+        context=context,
+    )
+    return resolver.verify_human_authorization(credential_id, message, signature)
 
 
 class RuntimeKeyResolver(Protocol):

--- a/tas_openai_bridge/kms.py
+++ b/tas_openai_bridge/kms.py
@@ -1,0 +1,60 @@
+"""KMS/HSM resolver interfaces for TAS authority and runtime keys."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import hashlib
+import hmac
+from typing import Protocol
+
+
+class RuntimeKeyResolver(Protocol):
+    """Verifies runtime attestations without exposing private runtime keys."""
+
+    def is_trusted_runtime_key(self, key_id: str) -> bool: ...
+    def sign_runtime(self, key_id: str, message: bytes) -> str: ...
+    def verify_runtime(self, key_id: str, message: bytes, signature: str) -> bool: ...
+
+
+class HumanAuthorizationResolver(Protocol):
+    """Verifies steward authorization envelopes without runtime private-key access."""
+
+    def is_known_authority(self, credential_id: str) -> bool: ...
+    def verify_human_authorization(self, credential_id: str, message: bytes, signature: str) -> bool: ...
+
+
+@dataclass(frozen=True)
+class HMACKeyResolver:
+    """Deterministic test double for KMS/HSM-backed resolvers."""
+
+    runtime_keys: dict[str, bytes] | None = None
+    human_keys: dict[str, bytes] | None = None
+
+    def _sign(self, key: bytes, message: bytes) -> str:
+        return "base64:" + hmac.new(key, message, hashlib.sha256).hexdigest()
+
+    def is_trusted_runtime_key(self, key_id: str) -> bool:
+        return key_id in (self.runtime_keys or {})
+
+    def sign_runtime(self, key_id: str, message: bytes) -> str:
+        if not self.is_trusted_runtime_key(key_id):
+            raise ValueError("Unknown runtime key")
+        return self._sign((self.runtime_keys or {})[key_id], message)
+
+    def verify_runtime(self, key_id: str, message: bytes, signature: str) -> bool:
+        if not self.is_trusted_runtime_key(key_id):
+            return False
+        return hmac.compare_digest(self.sign_runtime(key_id, message), signature)
+
+    def is_known_authority(self, credential_id: str) -> bool:
+        return credential_id in (self.human_keys or {})
+
+    def sign_human_authorization(self, credential_id: str, message: bytes) -> str:
+        if not self.is_known_authority(credential_id):
+            raise ValueError("Unknown authority key")
+        return self._sign((self.human_keys or {})[credential_id], message)
+
+    def verify_human_authorization(self, credential_id: str, message: bytes, signature: str) -> bool:
+        if not self.is_known_authority(credential_id):
+            return False
+        return hmac.compare_digest(self.sign_human_authorization(credential_id, message), signature)

--- a/tas_openai_bridge/registry_checkpoint.py
+++ b/tas_openai_bridge/registry_checkpoint.py
@@ -1,0 +1,303 @@
+"""Signed authority registry checkpoints and lookup proofs.
+
+This module intentionally models a small deterministic checkpoint contract before
+any Phoenix recovery logic. It gives runtimes a falsifiable registry snapshot hash
+that can be bound into runtime attestations.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import copy
+import hashlib
+import hmac
+import json
+from typing import Any, Protocol
+
+HASH_PREFIX = "sha256:"
+CHECKPOINT_SCHEMA = "tas.authority-registry-checkpoint.v1"
+
+
+class RegistryVerificationError(ValueError):
+    """Fail-closed registry verification error for malformed or invalid evidence."""
+
+
+def canonicalize(payload: dict[str, Any]) -> bytes:
+    return json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+
+
+def canonical_hash(payload: dict[str, Any]) -> str:
+    return HASH_PREFIX + hashlib.sha256(canonicalize(payload)).hexdigest()
+
+
+def _parse_time(value: str, field_name: str) -> datetime:
+    if not isinstance(value, str):
+        raise RegistryVerificationError(f"{field_name} must be an RFC3339 string")
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise RegistryVerificationError(f"Malformed {field_name}") from exc
+    if parsed.tzinfo is None:
+        raise RegistryVerificationError(f"{field_name} must be timezone-aware")
+    return parsed
+
+
+def _coerce_now(now: datetime | None) -> datetime:
+    current = now or datetime.now(timezone.utc)
+    if current.tzinfo is None:
+        raise RegistryVerificationError("now must be timezone-aware")
+    return current
+
+
+def _require_hash(value: Any, field_name: str) -> None:
+    if not isinstance(value, str) or not value.startswith(HASH_PREFIX):
+        raise RegistryVerificationError(f"{field_name} must be a sha256 string")
+
+
+def _require_resolver(resolver: Any) -> None:
+    has_trust_check = callable(getattr(resolver, "is_trusted_registry_key", None))
+    has_verify = callable(getattr(resolver, "verify", None))
+    if resolver is None or not has_trust_check or not has_verify:
+        raise RegistryVerificationError("Registry signature verifier is required")
+
+
+@dataclass(frozen=True)
+class RegistryCheckpoint:
+    schema: str
+    registry_id: str
+    sequence: int
+    issued_at: str
+    valid_until: str
+    previous_checkpoint_hash: str
+    entries_root: str
+    entry_count: int
+    signing_key_id: str
+    signature: str
+    checkpoint_hash: str
+
+    def unsigned_body(self) -> dict[str, Any]:
+        body = self.to_dict()
+        body["signature"] = None
+        body.pop("checkpoint_hash", None)
+        return body
+
+    def signed_body(self) -> dict[str, Any]:
+        body = self.to_dict()
+        body.pop("checkpoint_hash", None)
+        return body
+
+    def computed_checkpoint_hash(self) -> str:
+        return canonical_hash(self.signed_body())
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema": self.schema,
+            "registry_id": self.registry_id,
+            "sequence": self.sequence,
+            "issued_at": self.issued_at,
+            "valid_until": self.valid_until,
+            "previous_checkpoint_hash": self.previous_checkpoint_hash,
+            "entries_root": self.entries_root,
+            "entry_count": self.entry_count,
+            "signing_key_id": self.signing_key_id,
+            "signature": self.signature,
+            "checkpoint_hash": self.checkpoint_hash,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> "RegistryCheckpoint":
+        return cls(**payload)
+
+
+@dataclass(frozen=True)
+class AuthorityLookupProof:
+    anchor_id: str
+    status: str
+    authority_epoch: int
+    effective_at: str
+    revoked_at: str | None
+    scope_policy_hash: str
+    inclusion_proof: tuple[str, ...]
+    checkpoint_hash: str
+
+    def record(self) -> dict[str, Any]:
+        return {
+            "anchor_id": self.anchor_id,
+            "status": self.status,
+            "authority_epoch": self.authority_epoch,
+            "effective_at": self.effective_at,
+            "revoked_at": self.revoked_at,
+            "scope_policy_hash": self.scope_policy_hash,
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        body = self.record()
+        body["inclusion_proof"] = list(self.inclusion_proof)
+        body["checkpoint_hash"] = self.checkpoint_hash
+        return body
+
+
+@dataclass
+class AntiRollbackState:
+    registry_id: str
+    highest_accepted_sequence: int = 0
+    highest_accepted_checkpoint_hash: str = "sha256:genesis"
+    accepted_at: str | None = None
+
+
+class RegistrySigningKeyResolver(Protocol):
+    def is_trusted_registry_key(self, key_id: str) -> bool: ...
+    def verify(self, key_id: str, message: bytes, signature: str) -> bool: ...
+
+
+class InMemoryRegistrySigningKeyResolver:
+    """Test resolver; production can adapt this Protocol to KMS/HSM verify APIs."""
+
+    def __init__(self, keys: dict[str, bytes]):
+        if keys is None:
+            raise RegistryVerificationError("Registry signature verifier keys are required")
+        self._keys = dict(keys)
+
+    def is_trusted_registry_key(self, key_id: str) -> bool:
+        return key_id in self._keys
+
+    def sign(self, key_id: str, message: bytes) -> str:
+        return "base64:" + hmac.new(self._keys[key_id], message, hashlib.sha256).hexdigest()
+
+    def verify(self, key_id: str, message: bytes, signature: str) -> bool:
+        if key_id not in self._keys:
+            return False
+        return hmac.compare_digest(self.sign(key_id, message), signature)
+
+
+def entries_root(records: list[dict[str, Any]]) -> str:
+    leaves = sorted(canonical_hash(record) for record in records)
+    return canonical_hash({"leaves": leaves})
+
+
+def verify_inclusion_proof(proof: AuthorityLookupProof, checkpoint: RegistryCheckpoint) -> bool:
+    # Minimal v1 proof format: the proof carries the complete sorted checkpoint leaf set.
+    # This favors an auditable contract over a partial Merkle implementation in v1.
+    if proof is None:
+        raise RegistryVerificationError("Authority lookup proof is required")
+    if checkpoint.entry_count <= 0:
+        raise RegistryVerificationError("Authority inclusion proof requires checkpoint entries")
+    if not isinstance(proof.inclusion_proof, tuple) or not proof.inclusion_proof:
+        raise RegistryVerificationError("Authority inclusion proof is required")
+    for idx, item in enumerate(proof.inclusion_proof):
+        _require_hash(item, f"inclusion_proof[{idx}]")
+    if canonical_hash(proof.record()) not in proof.inclusion_proof:
+        return False
+    return canonical_hash({"leaves": sorted(proof.inclusion_proof)}) == checkpoint.entries_root
+
+
+def verify_registry_checkpoint(
+    checkpoint: RegistryCheckpoint,
+    resolver: RegistrySigningKeyResolver,
+    anti_rollback: AntiRollbackState,
+    *,
+    now: datetime | None = None,
+    minimum_accepted_sequence: int = 0,
+) -> None:
+    _require_resolver(resolver)
+    if checkpoint is None:
+        raise RegistryVerificationError("Registry checkpoint is required")
+    if anti_rollback is None:
+        raise RegistryVerificationError("Anti-rollback state is required")
+    now = _coerce_now(now)
+    _parse_time(checkpoint.issued_at, "issued_at")
+    if _parse_time(checkpoint.valid_until, "valid_until") <= now:
+        raise RegistryVerificationError("Registry checkpoint is stale")
+    for field_name in ("previous_checkpoint_hash", "entries_root", "checkpoint_hash"):
+        _require_hash(getattr(checkpoint, field_name, None), field_name)
+    if checkpoint.schema != CHECKPOINT_SCHEMA:
+        raise RegistryVerificationError("Unsupported registry checkpoint schema")
+    if checkpoint.registry_id != anti_rollback.registry_id:
+        raise RegistryVerificationError("Registry checkpoint is for a different registry")
+    if checkpoint.sequence < minimum_accepted_sequence:
+        raise RegistryVerificationError("Registry checkpoint is below minimum accepted sequence")
+    if checkpoint.sequence < anti_rollback.highest_accepted_sequence:
+        raise RegistryVerificationError("Registry checkpoint rollback detected")
+    if checkpoint.sequence == anti_rollback.highest_accepted_sequence:
+        if checkpoint.checkpoint_hash != anti_rollback.highest_accepted_checkpoint_hash:
+            raise RegistryVerificationError("Registry checkpoint equivocation detected")
+    elif checkpoint.previous_checkpoint_hash != anti_rollback.highest_accepted_checkpoint_hash:
+        raise RegistryVerificationError("Registry checkpoint does not extend accepted lineage")
+    if not isinstance(checkpoint.entry_count, int) or checkpoint.entry_count < 0:
+        raise RegistryVerificationError("Registry checkpoint entry_count is invalid")
+    if not resolver.is_trusted_registry_key(checkpoint.signing_key_id):
+        raise RegistryVerificationError("Untrusted registry signing key")
+    if checkpoint.checkpoint_hash != checkpoint.computed_checkpoint_hash():
+        raise RegistryVerificationError("Registry checkpoint hash mismatch")
+    if not resolver.verify(
+        checkpoint.signing_key_id,
+        canonicalize(checkpoint.unsigned_body()),
+        checkpoint.signature,
+    ):
+        raise RegistryVerificationError("Invalid registry checkpoint signature")
+
+
+def accept_authority_lookup(
+    checkpoint: RegistryCheckpoint,
+    proof: AuthorityLookupProof,
+    resolver: RegistrySigningKeyResolver,
+    anti_rollback: AntiRollbackState,
+    *,
+    now: datetime | None = None,
+    minimum_accepted_sequence: int = 0,
+) -> str:
+    verify_registry_checkpoint(
+        checkpoint,
+        resolver,
+        anti_rollback,
+        now=now,
+        minimum_accepted_sequence=minimum_accepted_sequence,
+    )
+    if proof is None:
+        raise RegistryVerificationError("Authority lookup proof is required")
+    for field_name in ("anchor_id", "status", "scope_policy_hash", "checkpoint_hash"):
+        if getattr(proof, field_name, None) is None:
+            raise RegistryVerificationError(f"Authority proof missing {field_name}")
+    _parse_time(proof.effective_at, "effective_at")
+    _require_hash(proof.scope_policy_hash, "scope_policy_hash")
+    _require_hash(proof.checkpoint_hash, "proof.checkpoint_hash")
+    if proof.checkpoint_hash != checkpoint.checkpoint_hash:
+        raise RegistryVerificationError("Proof is not bound to checkpoint")
+    if proof.status != "ACTIVE" or proof.revoked_at is not None:
+        raise RegistryVerificationError("Authority is not active")
+    if not verify_inclusion_proof(proof, checkpoint):
+        raise RegistryVerificationError("Invalid authority inclusion proof")
+    anti_rollback.highest_accepted_sequence = checkpoint.sequence
+    anti_rollback.highest_accepted_checkpoint_hash = checkpoint.checkpoint_hash
+    anti_rollback.accepted_at = _coerce_now(now).isoformat()
+    return checkpoint.checkpoint_hash
+
+
+def build_checkpoint(
+    *,
+    registry_id: str,
+    sequence: int,
+    issued_at: str,
+    valid_until: str,
+    previous_checkpoint_hash: str,
+    records: list[dict[str, Any]],
+    signing_key_id: str,
+    resolver: InMemoryRegistrySigningKeyResolver,
+) -> RegistryCheckpoint:
+    unsigned = {
+        "schema": CHECKPOINT_SCHEMA,
+        "registry_id": registry_id,
+        "sequence": sequence,
+        "issued_at": issued_at,
+        "valid_until": valid_until,
+        "previous_checkpoint_hash": previous_checkpoint_hash,
+        "entries_root": entries_root(records),
+        "entry_count": len(records),
+        "signing_key_id": signing_key_id,
+        "signature": None,
+    }
+    signed = copy.deepcopy(unsigned)
+    signed["signature"] = resolver.sign(signing_key_id, canonicalize(unsigned))
+    signed["checkpoint_hash"] = canonical_hash(signed)
+    return RegistryCheckpoint.from_dict(signed)

--- a/tas_openai_bridge/schemas.py
+++ b/tas_openai_bridge/schemas.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass, field
 from typing import Any, Mapping
 
 TAS_CANDIDATE_RESPONSE_SCHEMA: dict[str, Any] = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",
     "properties": {
         "decision": {

--- a/tests/tas_openai_bridge/test_registry_checkpoint_runtime.py
+++ b/tests/tas_openai_bridge/test_registry_checkpoint_runtime.py
@@ -13,6 +13,8 @@ from tas_openai_bridge import (
     accept_authority_lookup,
     audit_event,
     build_checkpoint,
+    human_authorization_message,
+    verify_human_authorization_envelope,
 )
 from tas_openai_bridge.registry_checkpoint import canonical_hash
 
@@ -305,3 +307,58 @@ def test_missing_verifier_and_empty_entry_checkpoint_fail_closed():
 
     with pytest.raises(RegistryVerificationError, match="keys are required"):
         InMemoryRegistrySigningKeyResolver(None)
+
+
+def test_human_authorization_envelope_binds_candidate_operation_and_domain():
+    resolver = HMACKeyResolver(human_keys={"ed25519:human": b"human-secret"})
+    message = human_authorization_message(
+        credential_id="ed25519:human",
+        candidate_hash="sha256:candidate",
+        requested_operation="openai.responses.create",
+        context={"lease_id": "lease-1"},
+    )
+    signature = resolver.sign_human_authorization("ed25519:human", message)
+
+    assert verify_human_authorization_envelope(
+        resolver,
+        credential_id="ed25519:human",
+        candidate_hash="sha256:candidate",
+        requested_operation="openai.responses.create",
+        signature=signature,
+        context={"lease_id": "lease-1"},
+    )
+    assert not verify_human_authorization_envelope(
+        resolver,
+        credential_id="ed25519:human",
+        candidate_hash="sha256:other-candidate",
+        requested_operation="openai.responses.create",
+        signature=signature,
+        context={"lease_id": "lease-1"},
+    )
+    assert not verify_human_authorization_envelope(
+        resolver,
+        credential_id="ed25519:human",
+        candidate_hash="sha256:candidate",
+        requested_operation="filesystem.write",
+        signature=signature,
+        context={"lease_id": "lease-1"},
+    )
+
+
+def test_unknown_human_authority_fails_closed():
+    resolver = HMACKeyResolver(human_keys={})
+
+    assert not verify_human_authorization_envelope(
+        resolver,
+        credential_id="ed25519:unknown",
+        candidate_hash="sha256:candidate",
+        requested_operation="openai.responses.create",
+        signature="base64:anything",
+    )
+
+    with pytest.raises(ValueError, match="credential_id is required"):
+        human_authorization_message(
+            credential_id="",
+            candidate_hash="sha256:candidate",
+            requested_operation="openai.responses.create",
+        )

--- a/tests/tas_openai_bridge/test_registry_checkpoint_runtime.py
+++ b/tests/tas_openai_bridge/test_registry_checkpoint_runtime.py
@@ -1,0 +1,307 @@
+from datetime import datetime, timezone
+
+import pytest
+
+from tas_openai_bridge import (
+    AntiRollbackState,
+    AuthorityLookupProof,
+    GovernanceRuntimeLedger,
+    HMACKeyResolver,
+    InMemoryRegistrySigningKeyResolver,
+    RegistryCheckpoint,
+    RegistryVerificationError,
+    accept_authority_lookup,
+    audit_event,
+    build_checkpoint,
+)
+from tas_openai_bridge.registry_checkpoint import canonical_hash
+
+NOW = datetime(2026, 7, 11, 13, 0, tzinfo=timezone.utc)
+
+
+def active_record(anchor_id="ed25519:human"):
+    return {
+        "anchor_id": anchor_id,
+        "status": "ACTIVE",
+        "authority_epoch": 7,
+        "effective_at": "2026-07-11T12:45:00Z",
+        "revoked_at": None,
+        "scope_policy_hash": "sha256:scope",
+    }
+
+
+def checkpoint_and_proof(record=None, previous="sha256:genesis", sequence=1):
+    resolver = InMemoryRegistrySigningKeyResolver({"ed25519:registry": b"registry-secret"})
+    record = record or active_record()
+    checkpoint = build_checkpoint(
+        registry_id="tas://authority-registry/primary",
+        sequence=sequence,
+        issued_at="2026-07-11T13:00:00Z",
+        valid_until="2026-07-11T13:05:00Z",
+        previous_checkpoint_hash=previous,
+        records=[record],
+        signing_key_id="ed25519:registry",
+        resolver=resolver,
+    )
+    proof = AuthorityLookupProof(
+        **record,
+        inclusion_proof=(canonical_hash(record),),
+        checkpoint_hash=checkpoint.checkpoint_hash,
+    )
+    return resolver, checkpoint, proof
+
+
+def test_registry_checkpoint_acceptance_updates_anti_rollback_state():
+    resolver, checkpoint, proof = checkpoint_and_proof()
+    anti_rollback = AntiRollbackState("tas://authority-registry/primary")
+
+    accepted_hash = accept_authority_lookup(
+        checkpoint, proof, resolver, anti_rollback, now=NOW
+    )
+
+    assert accepted_hash == checkpoint.checkpoint_hash
+    assert anti_rollback.highest_accepted_sequence == 1
+    assert anti_rollback.highest_accepted_checkpoint_hash == checkpoint.checkpoint_hash
+
+
+def test_unknown_registry_key_fails_closed():
+    _, checkpoint, proof = checkpoint_and_proof()
+    untrusted = InMemoryRegistrySigningKeyResolver({})
+
+    with pytest.raises(ValueError, match="Untrusted registry signing key"):
+        accept_authority_lookup(
+            checkpoint,
+            proof,
+            untrusted,
+            AntiRollbackState("tas://authority-registry/primary"),
+            now=NOW,
+        )
+
+
+def test_revoked_authority_and_bad_inclusion_are_rejected():
+    revoked = active_record()
+    revoked["status"] = "REVOKED"
+    revoked["revoked_at"] = "2026-07-11T12:50:00Z"
+    resolver, checkpoint, proof = checkpoint_and_proof(revoked)
+
+    with pytest.raises(ValueError, match="Authority is not active"):
+        accept_authority_lookup(
+            checkpoint,
+            proof,
+            resolver,
+            AntiRollbackState("tas://authority-registry/primary"),
+            now=NOW,
+        )
+
+    resolver, checkpoint, proof = checkpoint_and_proof()
+    bad_proof = AuthorityLookupProof(
+        **active_record("ed25519:other"),
+        inclusion_proof=(canonical_hash(active_record("ed25519:other")),),
+        checkpoint_hash=checkpoint.checkpoint_hash,
+    )
+    with pytest.raises(ValueError, match="Invalid authority inclusion proof"):
+        accept_authority_lookup(
+            checkpoint,
+            bad_proof,
+            resolver,
+            AntiRollbackState("tas://authority-registry/primary"),
+            now=NOW,
+        )
+
+
+def test_identical_checkpoint_reuse_is_allowed_but_rollback_lineage_and_stale_failures_are_rejected():
+    resolver, checkpoint, proof = checkpoint_and_proof()
+    anti = AntiRollbackState("tas://authority-registry/primary")
+    accept_authority_lookup(checkpoint, proof, resolver, anti, now=NOW)
+
+    assert accept_authority_lookup(checkpoint, proof, resolver, anti, now=NOW) == checkpoint.checkpoint_hash
+
+    _, old_checkpoint, old_proof = checkpoint_and_proof(sequence=1)
+    anti.highest_accepted_sequence = 2
+    anti.highest_accepted_checkpoint_hash = "sha256:accepted"
+    with pytest.raises(RegistryVerificationError, match="rollback"):
+        accept_authority_lookup(old_checkpoint, old_proof, resolver, anti, now=NOW)
+
+    anti.highest_accepted_sequence = 1
+    anti.highest_accepted_checkpoint_hash = checkpoint.checkpoint_hash
+    resolver2, checkpoint2, proof2 = checkpoint_and_proof(
+        previous="sha256:not-parent", sequence=2
+    )
+    with pytest.raises(RegistryVerificationError, match="lineage"):
+        accept_authority_lookup(checkpoint2, proof2, resolver2, anti, now=NOW)
+
+    resolver3 = InMemoryRegistrySigningKeyResolver({"ed25519:registry": b"registry-secret"})
+    stale = build_checkpoint(
+        registry_id="tas://authority-registry/primary",
+        sequence=2,
+        issued_at="2026-07-11T12:50:00Z",
+        valid_until="2026-07-11T12:59:00Z",
+        previous_checkpoint_hash=checkpoint.checkpoint_hash,
+        records=[active_record()],
+        signing_key_id="ed25519:registry",
+        resolver=resolver3,
+    )
+    stale_proof = AuthorityLookupProof(
+        **active_record(),
+        inclusion_proof=(canonical_hash(active_record()),),
+        checkpoint_hash=stale.checkpoint_hash,
+    )
+    with pytest.raises(ValueError, match="stale"):
+        accept_authority_lookup(stale, stale_proof, resolver3, anti, now=NOW)
+
+
+def test_resume_decision_results_in_commit_authorized_and_runtime_signature_audits():
+    runtime = HMACKeyResolver(runtime_keys={"ed25519:runtime": b"runtime-secret"})
+    ledger = GovernanceRuntimeLedger(runtime, "ed25519:runtime")
+
+    event = ledger.commit_transition(
+        event_type="RESUME_DECISION",
+        next_state="COMMIT_AUTHORIZED",
+        decision={"credential_id": "ed25519:human", "candidate_hash": "sha256:candidate"},
+        lease_id="lease-1",
+        lease_usage_count=1,
+        registry_checkpoint_hash="sha256:checkpoint",
+    )
+
+    assert event["event_type"] == "RESUME_DECISION"
+    assert event["decision"]["state"] == "COMMIT_AUTHORIZED"
+    assert event["runtime_attestation"]["registry_checkpoint_hash"] == "sha256:checkpoint"
+    audit_event(event, runtime)
+
+
+def test_runtime_signature_projection_is_stable_after_signature_inserted():
+    runtime = HMACKeyResolver(runtime_keys={"ed25519:runtime": b"runtime-secret"})
+    ledger = GovernanceRuntimeLedger(runtime, "ed25519:runtime")
+    event = ledger.commit_transition(
+        event_type="RESUME_DECISION",
+        next_state="COMMIT_AUTHORIZED",
+        decision={"credential_id": "ed25519:human", "candidate_hash": "sha256:candidate"},
+        lease_id="lease-1",
+        lease_usage_count=1,
+        registry_checkpoint_hash="sha256:checkpoint",
+    )
+
+    event["runtime_attestation"]["runtime_signature"] = "base64:tampered"
+    with pytest.raises(ValueError, match="Invalid runtime signature"):
+        audit_event(event, runtime)
+
+
+def test_event_type_and_state_are_audited_together():
+    runtime = HMACKeyResolver(runtime_keys={"ed25519:runtime": b"runtime-secret"})
+    ledger = GovernanceRuntimeLedger(runtime, "ed25519:runtime")
+    event = ledger.commit_transition(
+        event_type="RESUME_DECISION",
+        next_state="COMMIT_AUTHORIZED",
+        decision={"credential_id": "ed25519:human", "candidate_hash": "sha256:candidate"},
+        lease_id="lease-1",
+        lease_usage_count=1,
+        registry_checkpoint_hash="sha256:checkpoint",
+    )
+    event["decision"]["state"] = "EXECUTING"
+    with pytest.raises(ValueError, match="Invalid audited transition"):
+        audit_event(event, runtime)
+
+
+def test_untrusted_runtime_key_is_rejected():
+    runtime = HMACKeyResolver(runtime_keys={})
+    with pytest.raises(ValueError, match="Runtime key is not trusted"):
+        GovernanceRuntimeLedger(runtime, "ed25519:runtime")
+
+
+def test_same_sequence_different_hash_is_equivocation():
+    resolver, checkpoint, proof = checkpoint_and_proof()
+    anti = AntiRollbackState("tas://authority-registry/primary")
+    accept_authority_lookup(checkpoint, proof, resolver, anti, now=NOW)
+
+    other_record = active_record("ed25519:other")
+    equivocal = build_checkpoint(
+        registry_id="tas://authority-registry/primary",
+        sequence=1,
+        issued_at="2026-07-11T13:00:00Z",
+        valid_until="2026-07-11T13:05:00Z",
+        previous_checkpoint_hash="sha256:genesis",
+        records=[other_record],
+        signing_key_id="ed25519:registry",
+        resolver=resolver,
+    )
+    equivocal_proof = AuthorityLookupProof(
+        **other_record,
+        inclusion_proof=(canonical_hash(other_record),),
+        checkpoint_hash=equivocal.checkpoint_hash,
+    )
+
+    with pytest.raises(RegistryVerificationError, match="equivocation"):
+        accept_authority_lookup(equivocal, equivocal_proof, resolver, anti, now=NOW)
+
+
+def test_malformed_inputs_are_registry_verification_errors():
+    resolver, checkpoint, proof = checkpoint_and_proof()
+    anti = AntiRollbackState("tas://authority-registry/primary")
+
+    with pytest.raises(RegistryVerificationError, match="now must be timezone-aware"):
+        accept_authority_lookup(
+            checkpoint, proof, resolver, anti, now=datetime(2026, 7, 11, 13, 0)
+        )
+
+    malformed_time = RegistryCheckpoint.from_dict(
+        {**checkpoint.to_dict(), "valid_until": "not-a-time"}
+    )
+    with pytest.raises(RegistryVerificationError, match="Malformed valid_until"):
+        accept_authority_lookup(malformed_time, proof, resolver, anti, now=NOW)
+
+    malformed_hash = RegistryCheckpoint.from_dict(
+        {**checkpoint.to_dict(), "entries_root": 42}
+    )
+    with pytest.raises(RegistryVerificationError, match="entries_root must be a sha256 string"):
+        accept_authority_lookup(malformed_hash, proof, resolver, anti, now=NOW)
+
+    with pytest.raises(RegistryVerificationError, match="Authority lookup proof is required"):
+        accept_authority_lookup(checkpoint, None, resolver, anti, now=NOW)
+
+    missing_record = AuthorityLookupProof(
+        anchor_id=None,
+        status="ACTIVE",
+        authority_epoch=7,
+        effective_at="2026-07-11T12:45:00Z",
+        revoked_at=None,
+        scope_policy_hash="sha256:scope",
+        inclusion_proof=(canonical_hash(active_record()),),
+        checkpoint_hash=checkpoint.checkpoint_hash,
+    )
+    with pytest.raises(RegistryVerificationError, match="Authority proof missing anchor_id"):
+        accept_authority_lookup(checkpoint, missing_record, resolver, anti, now=NOW)
+
+
+def test_missing_verifier_and_empty_entry_checkpoint_fail_closed():
+    resolver, checkpoint, proof = checkpoint_and_proof()
+    anti = AntiRollbackState("tas://authority-registry/primary")
+
+    with pytest.raises(RegistryVerificationError, match="signature verifier is required"):
+        accept_authority_lookup(checkpoint, proof, None, anti, now=NOW)
+
+    empty_checkpoint = build_checkpoint(
+        registry_id="tas://authority-registry/primary",
+        sequence=1,
+        issued_at="2026-07-11T13:00:00Z",
+        valid_until="2026-07-11T13:05:00Z",
+        previous_checkpoint_hash="sha256:genesis",
+        records=[],
+        signing_key_id="ed25519:registry",
+        resolver=resolver,
+    )
+    empty_proof = AuthorityLookupProof(
+        **active_record(),
+        inclusion_proof=(canonical_hash(active_record()),),
+        checkpoint_hash=empty_checkpoint.checkpoint_hash,
+    )
+    with pytest.raises(RegistryVerificationError, match="requires checkpoint entries"):
+        accept_authority_lookup(
+            empty_checkpoint,
+            empty_proof,
+            resolver,
+            AntiRollbackState("tas://authority-registry/primary"),
+            now=NOW,
+        )
+
+    with pytest.raises(RegistryVerificationError, match="keys are required"):
+        InMemoryRegistrySigningKeyResolver(None)


### PR DESCRIPTION
### Motivation

- Introduce a deterministic, auditable registry checkpoint contract so runtimes can bind attestations to a verifiable registry snapshot and prevent rollback or equivocation. 
- Provide a runtime governance ledger that hash-links governance events and embeds runtime attestations with verifiable runtime signatures. 
- Add lightweight KMS/HSM test doubles to sign and verify runtime and human authorization envelopes for unit testing and local development.

### Description

- Add `tas_openai_bridge/registry_checkpoint.py` implementing `RegistryCheckpoint`, `AuthorityLookupProof`, `AntiRollbackState`, checkpoint canonicalization and hashing, inclusion proof verification, `InMemoryRegistrySigningKeyResolver`, `verify_registry_checkpoint`, `accept_authority_lookup`, and `build_checkpoint` functions. 
- Add `tas_openai_bridge/governance_runtime.py` implementing `GovernanceRuntimeLedger`, event signing helpers (`runtime_signing_message`, `final_event_hash`, `runtime_attestation_body`) and `audit_event` to validate runtime attestations. 
- Add `tas_openai_bridge/kms.py` which defines `RuntimeKeyResolver` and `HumanAuthorizationResolver` protocols and a deterministic `HMACKeyResolver` test double. 
- Export new symbols from `tas_openai_bridge/__init__.py` and add a small JSON Schema hint to `schemas.py` by adding `"$schema"`. 
- Add comprehensive unit tests in `tests/tas_openai_bridge/test_registry_checkpoint_runtime.py` covering checkpoint building/acceptance, anti-rollback semantics, inclusion proofs, equivocation, malformed inputs, and runtime ledger signing/auditing.

### Testing

- Executed `pytest tests/tas_openai_bridge/test_registry_checkpoint_runtime.py` which runs the included unit tests exercising checkpoint acceptance, anti-rollback behavior, inclusion proof verification, signature verification, and `GovernanceRuntimeLedger` transitions, and all tests passed. 
- The test suite uses `HMACKeyResolver` and `InMemoryRegistrySigningKeyResolver` as deterministic test doubles to validate signing and verification paths.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a52fbdd67048333bf9a68acc38ed489)