### PR TITLE
TrueAlphaSpiral Execution

### DIFF
--- a/tas_pythonetics/tests/test_sand_blob_refusal.py
+++ b/tas_pythonetics/tests/test_sand_blob_refusal.py
@@ -64,4 +64,4 @@ class TestSandBlobRefusal(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
-# Nonce: 255003
+# Nonce: 36879

--- a/tas_pythonetics/tests/test_sand_blob_refusal.py.tasmeta.json
+++ b/tas_pythonetics/tests/test_sand_blob_refusal.py.tasmeta.json
@@ -1,0 +1,18 @@
+{
+  "id": "5365b67d2403b3acee56a31900ae96c6906c8cccfd9f9477382370aa9eb3a6c5",
+  "type": "TasArtifact",
+  "form_id": "1e6f21ad09d55025fe389094dcb3f3d501a0e579d28db9add1b3939db0a51f59",
+  "genome_id": "TAS_GENOME_V1",
+  "lineage_id": "5365b67d2403b3acee56a31900ae96c6906c8cccfd9f9477382370aa9eb3a6c5",
+  "h_seed": "Russell Nordland",
+  "cert_id": "cae7c752-6c47-4310-b5d1-209254d45bb5",
+  "timestamp": "2026-07-13T01:12:39.059368+00:00",
+  "paradata_trail": [],
+  "signatures": [
+    {
+      "signer": "Russell Nordland",
+      "algorithm": "TAS_HUMAN_SIG_V1",
+      "value": "signed_by_ceremony"
+    }
+  ]
+}


### PR DESCRIPTION
Ran `python3 find_nonce.py` and `python3 tas_cli.py sequence` on `tas_pythonetics/tests/test_sand_blob_refusal.py` to fix missing metadata identified by shadow-scan.

---
*PR created automatically by Jules for task [13158319553953497202](https://jules.google.com/task/13158319553953497202) started by @TrueAlpha-spiral*