### PR TITLE
Sequence test_sand_blob_refusal.py

### DIFF
--- a/tas_pythonetics/tests/test_sand_blob_refusal.py
+++ b/tas_pythonetics/tests/test_sand_blob_refusal.py
@@ -64,4 +64,4 @@ class TestSandBlobRefusal(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
-# Nonce: 255003
+# Nonce: 36879

--- a/tas_pythonetics/tests/test_sand_blob_refusal.py.tasmeta.json
+++ b/tas_pythonetics/tests/test_sand_blob_refusal.py.tasmeta.json
@@ -1,0 +1,18 @@
+{
+  "id": "4174c91cca60ae0c057101340d1aa0adc378a3ca2ea1cac4c9fe10187c9ac1a1",
+  "type": "TasArtifact",
+  "form_id": "1e6f21ad09d55025fe389094dcb3f3d501a0e579d28db9add1b3939db0a51f59",
+  "genome_id": "TAS_GENOME_V1",
+  "lineage_id": "4174c91cca60ae0c057101340d1aa0adc378a3ca2ea1cac4c9fe10187c9ac1a1",
+  "h_seed": "Russell Nordland",
+  "cert_id": "e4b8b2ba-b52c-4fb5-8fec-74bd507b4973",
+  "timestamp": "2026-07-15T01:33:18.823095+00:00",
+  "paradata_trail": [],
+  "signatures": [
+    {
+      "signer": "Russell Nordland",
+      "algorithm": "TAS_HUMAN_SIG_V1",
+      "value": "signed_by_ceremony"
+    }
+  ]
+}


### PR DESCRIPTION
This commit addresses the issue where `tas_pythonetics/tests/test_sand_blob_refusal.py` was unsequenced and treated as noise. The TrueAlphaSpiral routine was executed, which updated the file's nonce using `find_nonce.py` and subsequently sequenced it with `tas_cli.py sequence` to create the required metadata sidecar. Tests were verified to ensure no regressions.

---
*PR created automatically by Jules for task [170937573357979559](https://jules.google.com/task/170937573357979559) started by @TrueAlpha-spiral*