### PR TITLE
Harden deterministic Logos admission gate

### DIFF
--- a/tas_logos_gatekeeper.py
+++ b/tas_logos_gatekeeper.py
@@ -1,15 +1,38 @@
+import copy
+import decimal
 import hashlib
+import hmac
 import json
 import math
+import re
 import time
 from dataclasses import dataclass, field
-from typing import Any, Callable, Dict
+from datetime import datetime, timezone
+from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Tuple
+
+
+CANONICALIZATION_VERSION = "TAS-CJSON-1"
+RULE_SET_VERSION = "TAS-LOGOS-GATE-1"
+RECEIPT_VERSION = "TAS-DECISION-RECEIPT-1"
+AUTHORIZATION_DOMAIN = "TAS-LINEAGE-AUTHORIZATION-1"
+RECEIPT_DOMAIN = "TAS-GATEKEEPER-RECEIPT-1"
+
+_HASH_RE = re.compile(r"^[0-9a-f]{64}$")
 
 
 class SovereignStructuralViolation(Exception):
     """Raised when an execution trace violates the mathematical bounds of Log(os)."""
 
     pass
+
+
+class GatekeeperError(Exception):
+    """Stable, fail-closed gatekeeper error."""
+
+    def __init__(self, code: str, detail: str):
+        super().__init__(detail)
+        self.code = code
+        self.detail = detail
 
 
 @dataclass(frozen=True)
@@ -23,16 +46,13 @@ class LogosRefusalReceipt:
 
 
 class LogosValidationLoop:
+    """Legacy density gate retained for compatibility with existing callers."""
+
     def __init__(self, invariant_check: Callable[[], bool], min_density_floor: float = 0.15):
-        """
-        Initializes the Logos validation loop with a calibrated minimum density floor.
-        Payloads falling below this floor represent high-volume, low-density noise.
-        """
         self._invariant_check = invariant_check
         self._min_density_floor = min_density_floor
 
     def _calculate_shannon_entropy(self, payload_str: str) -> float:
-        """Measures the statistical character entropy (H) of the token stream."""
         if not payload_str:
             return 0.0
         frequencies: Dict[str, int] = {}
@@ -49,54 +69,43 @@ class LogosValidationLoop:
     def evaluate_logos_bounds(
         self, current_state_hash: bytes, manifest: Dict[str, Any], nonce: int
     ) -> bool:
-        """
-        Validates state transition viability under strict Log(os) constraints.
-        Execution passes IF AND ONLY IF lineage balances, invariants hold,
-        and the structural density meets or exceeds the minimum threshold floor.
-        """
         observed_entropy = 0.0
         logos_density = 1.0
         parent_hash_hex = current_state_hash.hex()
 
         try:
-            # 1. Lineage Trajectory Consistency
             lineage_match = manifest.get("lineage_parent_hash") == current_state_hash
-
-            # 2. Invariant Alignment (Phi Check)
             invariants_held = self._invariant_check()
-
-            # 3. Log(os) Scale Efficiency Evaluation
             payload_data = json.dumps(manifest.get("payload_vector", {}), sort_keys=True)
             payload_length = len(payload_data)
 
             if payload_length > 0:
                 observed_entropy = self._calculate_shannon_entropy(payload_data)
-                # Calibrated formula: bits of entropy scaled by the log of length over total footprint.
-                # Large, repetitive payloads drive this value toward zero; dense, varied payloads score higher.
                 logos_density = (observed_entropy * math.log(payload_length)) / payload_length
             else:
-                logos_density = 0.0  # Empty payloads carry zero structural work
+                logos_density = 0.0
 
-            # Corrected biconditional gate: density must be AT OR ABOVE the floor.
-            if not (lineage_match and invariants_held and (logos_density >= self._min_density_floor)):
+            if not (
+                lineage_match
+                and invariants_held
+                and logos_density >= self._min_density_floor
+            ):
                 raise SovereignStructuralViolation(
                     f"Biconditional collapse. Lineage: {lineage_match}, "
                     f"Invariants: {invariants_held}, Density: {logos_density:.4f} "
                     f"(Floor: {self._min_density_floor})"
                 )
-
             return True
 
-        except Exception as e:
+        except Exception as exc:
             self._engage_sentient_lock(
-                nonce, parent_hash_hex, observed_entropy, logos_density, str(e)
+                nonce, parent_hash_hex, observed_entropy, logos_density, str(exc)
             )
             return False
 
     def _engage_sentient_lock(
         self, nonce: int, parent_hash: str, entropy: float, density: float, fault: str
     ) -> None:
-        """Halts the execution pipeline and records the non-compliance witness packet."""
         receipt = LogosRefusalReceipt(
             nonce=nonce,
             parent_hash=parent_hash,
@@ -105,7 +114,485 @@ class LogosValidationLoop:
         )
         print(f"[SENTIENT_LOCK] Execution context frozen by Logos Layer. Fault: {fault}")
         print(
-            f"[ITL_RECORD] Non-compliance witness packet compiled:\n"
+            "[ITL_RECORD] Non-compliance witness packet compiled:\n"
             f"{json.dumps(receipt.__dict__, default=str, indent=2)}"
         )
-# Nonce: 80786
+
+
+class _CanonicalBudget:
+    def __init__(self, max_depth: int, max_nodes: int):
+        self.max_depth = max_depth
+        self.remaining_nodes = max_nodes
+
+    def consume(self, depth: int) -> None:
+        if depth > self.max_depth:
+            raise GatekeeperError("MAX_DEPTH_EXCEEDED", "JSON nesting exceeds the configured limit.")
+        self.remaining_nodes -= 1
+        if self.remaining_nodes < 0:
+            raise GatekeeperError("MAX_NODES_EXCEEDED", "JSON node count exceeds the configured limit.")
+
+
+def _reject_duplicate_keys(pairs: Sequence[Tuple[str, Any]]) -> Dict[str, Any]:
+    result: Dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise GatekeeperError("DUPLICATE_KEY", "Duplicate JSON object keys are forbidden.")
+        result[key] = value
+    return result
+
+
+def _reject_json_constant(value: str) -> None:
+    raise GatekeeperError("NON_FINITE_NUMBER", f"JSON constant {value!r} is forbidden.")
+
+
+def _validate_text(value: str) -> None:
+    for char in value:
+        codepoint = ord(char)
+        if 0xD800 <= codepoint <= 0xDFFF:
+            raise GatekeeperError("INVALID_UNICODE", "Unicode surrogate code points are forbidden.")
+
+
+def _canonical_decimal(value: decimal.Decimal) -> bytes:
+    if not value.is_finite():
+        raise GatekeeperError("NON_FINITE_NUMBER", "Non-finite numbers are forbidden.")
+
+    if value.is_zero():
+        return b"0"
+
+    digits = len(value.as_tuple().digits)
+    adjusted = value.adjusted()
+    if digits > 128 or abs(adjusted) > 308:
+        raise GatekeeperError("NUMBER_OUT_OF_RANGE", "Number exceeds canonical numeric bounds.")
+
+    normalized = value.normalize()
+    rendered = format(normalized, "f")
+    if "." in rendered:
+        rendered = rendered.rstrip("0").rstrip(".")
+    if rendered == "-0":
+        rendered = "0"
+    return rendered.encode("ascii")
+
+
+def _serialize_canonical(
+    obj: Any,
+    *,
+    max_depth: int = 64,
+    max_nodes: int = 100_000,
+) -> bytes:
+    budget = _CanonicalBudget(max_depth=max_depth, max_nodes=max_nodes)
+
+    def encode(value: Any, depth: int) -> bytes:
+        budget.consume(depth)
+
+        if value is None:
+            return b"null"
+        if isinstance(value, bool):
+            return b"true" if value else b"false"
+        if isinstance(value, int):
+            return _canonical_decimal(decimal.Decimal(value))
+        if isinstance(value, decimal.Decimal):
+            return _canonical_decimal(value)
+        if isinstance(value, str):
+            _validate_text(value)
+            return json.dumps(
+                value, ensure_ascii=False, separators=(",", ":")
+            ).encode("utf-8")
+        if isinstance(value, list):
+            return b"[" + b",".join(encode(item, depth + 1) for item in value) + b"]"
+        if isinstance(value, dict):
+            parts: List[bytes] = []
+            for key in sorted(value.keys()):
+                if not isinstance(key, str):
+                    raise GatekeeperError("NON_STRING_KEY", "JSON object keys must be strings.")
+                _validate_text(key)
+                encoded_key = json.dumps(
+                    key, ensure_ascii=False, separators=(",", ":")
+                ).encode("utf-8")
+                parts.append(encoded_key + b":" + encode(value[key], depth + 1))
+            return b"{" + b",".join(parts) + b"}"
+
+        raise GatekeeperError(
+            "UNSUPPORTED_TYPE",
+            f"Unsupported value type: {type(value).__name__}.",
+        )
+
+    return encode(obj, 0)
+
+
+class HMACReceiptSigner:
+    """Deterministic symmetric signer for tests and closed deployments."""
+
+    algorithm = "HMAC-SHA256"
+
+    def __init__(self, key_id: str, key: bytes):
+        if not key_id:
+            raise ValueError("key_id must be non-empty")
+        if not isinstance(key, bytes) or len(key) < 32:
+            raise ValueError("HMAC signing keys must contain at least 32 bytes")
+        self.key_id = key_id
+        self._key = key
+
+    def sign(self, receipt_bytes: bytes) -> Dict[str, str]:
+        domain_bound = RECEIPT_DOMAIN.encode("ascii") + b"\x00" + receipt_bytes
+        value = hmac.new(self._key, domain_bound, hashlib.sha256).hexdigest()
+        return {
+            "algorithm": self.algorithm,
+            "key_id": self.key_id,
+            "value": value,
+        }
+
+    def verify(self, receipt_bytes: bytes, signature: Mapping[str, str]) -> bool:
+        if (
+            signature.get("algorithm") != self.algorithm
+            or signature.get("key_id") != self.key_id
+        ):
+            return False
+        expected = self.sign(receipt_bytes)["value"]
+        supplied = signature.get("value", "")
+        return hmac.compare_digest(expected, supplied)
+
+
+class HMACLineageResolver:
+    """
+    Deterministic credential resolver for regression testing and closed deployments.
+
+    Production public-verification deployments should replace this resolver with
+    an asymmetric KMS/HSM-backed verifier.
+    """
+
+    algorithm = "HMAC-SHA256"
+
+    def __init__(self, credential_keys: Mapping[str, bytes]):
+        if not credential_keys:
+            raise ValueError("At least one credential key is required")
+        for credential_id, key in credential_keys.items():
+            if not credential_id or not isinstance(key, bytes) or len(key) < 32:
+                raise ValueError("Each credential must have an id and a 32-byte key")
+        self._credential_keys = dict(credential_keys)
+
+    @staticmethod
+    def build_envelope(
+        payload: Mapping[str, Any], authorization_hash: str
+    ) -> Dict[str, Any]:
+        lineage = payload.get("lineage", {})
+        return {
+            "domain": AUTHORIZATION_DOMAIN,
+            "canonicalization_version": CANONICALIZATION_VERSION,
+            "credential_id": payload.get("credential_id"),
+            "authorization_hash": authorization_hash,
+            "operation": payload.get("operation"),
+            "parent_hash": lineage.get("parent_hash") if isinstance(lineage, dict) else None,
+        }
+
+    def sign(self, payload: Mapping[str, Any], authorization_hash: str) -> str:
+        credential_id = payload.get("credential_id")
+        key = self._credential_keys.get(credential_id)
+        if key is None:
+            raise GatekeeperError("UNKNOWN_CREDENTIAL", "Credential is not registered.")
+        envelope = self.build_envelope(payload, authorization_hash)
+        envelope_bytes = _serialize_canonical(envelope)
+        value = hmac.new(key, envelope_bytes, hashlib.sha256).hexdigest()
+        return f"hmac-sha256:{value}"
+
+    def verify(
+        self, payload: Mapping[str, Any], authorization_hash: str
+    ) -> Tuple[bool, str]:
+        credential_id = payload.get("credential_id")
+        key = self._credential_keys.get(credential_id)
+        if key is None:
+            return False, "UNKNOWN_CREDENTIAL"
+
+        lineage = payload.get("lineage")
+        if not isinstance(lineage, dict):
+            return False, "INVALID_LINEAGE_OBJECT"
+
+        supplied = lineage.get("signature")
+        if not isinstance(supplied, str) or not supplied.startswith("hmac-sha256:"):
+            return False, "MALFORMED_SIGNATURE"
+
+        envelope = self.build_envelope(payload, authorization_hash)
+        envelope_bytes = _serialize_canonical(envelope)
+        expected = hmac.new(key, envelope_bytes, hashlib.sha256).hexdigest()
+        actual = supplied.split(":", 1)[1]
+        if not hmac.compare_digest(expected, actual):
+            return False, "SIGNATURE_MISMATCH"
+        return True, "SIGNATURE_VALID"
+
+
+class TASLogosGatekeeper:
+    """Gate 1 deterministic canonicalization, evaluation, and receipt pipeline."""
+
+    def __init__(
+        self,
+        *,
+        receipt_signer: HMACReceiptSigner,
+        lineage_verifier: Callable[[Mapping[str, Any], str], Tuple[bool, str]],
+        allowed_operations: Optional[Sequence[str]] = None,
+        gatekeeper_id: str = "tas_logos_gatekeeper",
+        max_raw_payload_bytes: int = 2 * 1024 * 1024,
+        max_state_delta_bytes: int = 1024 * 1024,
+        max_depth: int = 64,
+        max_nodes: int = 100_000,
+        clock: Optional[Callable[[], datetime]] = None,
+    ):
+        if receipt_signer is None or lineage_verifier is None:
+            raise ValueError("receipt_signer and lineage_verifier are required")
+        self.receipt_signer = receipt_signer
+        self.lineage_verifier = lineage_verifier
+        self.allowed_operations = frozenset(allowed_operations or ("MUTATE_STATE",))
+        self.gatekeeper_id = gatekeeper_id
+        self.max_raw_payload_bytes = max_raw_payload_bytes
+        self.max_state_delta_bytes = max_state_delta_bytes
+        self.max_depth = max_depth
+        self.max_nodes = max_nodes
+        self.clock = clock or (lambda: datetime.now(timezone.utc))
+
+    def parse_and_canonicalize(self, raw_payload: bytes) -> Tuple[Dict[str, Any], bytes]:
+        if not isinstance(raw_payload, bytes):
+            raise GatekeeperError("RAW_TYPE_INVALID", "Raw payload must be bytes.")
+        if len(raw_payload) > self.max_raw_payload_bytes:
+            raise GatekeeperError("RAW_PAYLOAD_TOO_LARGE", "Raw payload exceeds the configured limit.")
+
+        try:
+            text = raw_payload.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise GatekeeperError("INVALID_UTF8", "Payload is not valid UTF-8.") from exc
+
+        try:
+            parsed = json.loads(
+                text,
+                parse_float=decimal.Decimal,
+                parse_int=decimal.Decimal,
+                parse_constant=_reject_json_constant,
+                object_pairs_hook=_reject_duplicate_keys,
+            )
+        except GatekeeperError:
+            raise
+        except (json.JSONDecodeError, decimal.InvalidOperation, ValueError) as exc:
+            raise GatekeeperError("MALFORMED_JSON", "Payload is not valid strict JSON.") from exc
+
+        if not isinstance(parsed, dict):
+            raise GatekeeperError("ROOT_NOT_OBJECT", "Top-level JSON value must be an object.")
+
+        canonical = _serialize_canonical(
+            parsed, max_depth=self.max_depth, max_nodes=self.max_nodes
+        )
+        return parsed, canonical
+
+    def canonicalize(self, raw_payload: bytes) -> bytes:
+        _, canonical = self.parse_and_canonicalize(raw_payload)
+        return canonical
+
+    @staticmethod
+    def compute_hash(canonical_payload: bytes) -> str:
+        return hashlib.sha256(canonical_payload).hexdigest()
+
+    def compute_authorization_hash(self, payload: Mapping[str, Any]) -> str:
+        authorization_view = copy.deepcopy(dict(payload))
+        lineage = authorization_view.get("lineage")
+        if isinstance(lineage, dict):
+            lineage.pop("signature", None)
+        canonical = _serialize_canonical(
+            authorization_view,
+            max_depth=self.max_depth,
+            max_nodes=self.max_nodes,
+        )
+        return self.compute_hash(canonical)
+
+    def evaluate_invariants(
+        self,
+        payload: Dict[str, Any],
+        candidate_hash: str,
+        authorization_hash: str,
+    ) -> Tuple[bool, List[Dict[str, str]]]:
+        rules = (
+            ("INV_01_STRUCTURE", self._rule_has_mandatory_fields),
+            ("INV_02_SIGNATURE", self._rule_valid_lineage_signature),
+            ("INV_03_LINEAGE_LOOP", self._rule_no_circular_lineage),
+            ("INV_04_RESOURCE_BOUNDS", self._rule_within_resource_limits),
+        )
+
+        context = {
+            "payload": payload,
+            "candidate_hash": candidate_hash,
+            "authorization_hash": authorization_hash,
+        }
+        logs: List[Dict[str, str]] = []
+        all_passed = True
+
+        for rule_id, rule in rules:
+            try:
+                passed, detail_code = rule(context)
+            except Exception:
+                passed, detail_code = False, "RULE_EXCEPTION"
+
+            logs.append(
+                {
+                    "rule_id": rule_id,
+                    "status": "PASSED" if passed else "FAILED",
+                    "detail_code": detail_code,
+                }
+            )
+            all_passed = all_passed and passed
+
+        return all_passed, logs
+
+    def _rule_has_mandatory_fields(
+        self, context: Mapping[str, Any]
+    ) -> Tuple[bool, str]:
+        payload = context["payload"]
+        required = {"credential_id", "operation", "lineage", "state_delta"}
+        allowed = required | {"context"}
+
+        missing = required - set(payload)
+        if missing:
+            return False, "MISSING_MANDATORY_FIELDS"
+        if set(payload) - allowed:
+            return False, "UNKNOWN_TOP_LEVEL_FIELDS"
+        if not isinstance(payload.get("credential_id"), str) or not payload["credential_id"]:
+            return False, "INVALID_CREDENTIAL_ID"
+        if len(payload["credential_id"].encode("utf-8")) > 128:
+            return False, "CREDENTIAL_ID_TOO_LONG"
+        if payload.get("operation") not in self.allowed_operations:
+            return False, "OPERATION_NOT_ALLOWED"
+        if not isinstance(payload.get("lineage"), dict):
+            return False, "INVALID_LINEAGE_OBJECT"
+        if not isinstance(payload.get("state_delta"), dict):
+            return False, "INVALID_STATE_DELTA"
+        return True, "STRUCTURE_VALID"
+
+    def _rule_valid_lineage_signature(
+        self, context: Mapping[str, Any]
+    ) -> Tuple[bool, str]:
+        payload = context["payload"]
+        authorization_hash = context["authorization_hash"]
+        lineage = payload.get("lineage")
+        if not isinstance(lineage, dict):
+            return False, "INVALID_LINEAGE_OBJECT"
+        if "signature" not in lineage or "parent_hash" not in lineage:
+            return False, "LINEAGE_FIELDS_MISSING"
+        return self.lineage_verifier(payload, authorization_hash)
+
+    def _rule_no_circular_lineage(
+        self, context: Mapping[str, Any]
+    ) -> Tuple[bool, str]:
+        payload = context["payload"]
+        candidate_hash = context["candidate_hash"]
+        lineage = payload.get("lineage")
+        if not isinstance(lineage, dict):
+            return False, "INVALID_LINEAGE_OBJECT"
+
+        allowed_lineage_fields = {"parent_hash", "signature", "history"}
+        if set(lineage) - allowed_lineage_fields:
+            return False, "UNKNOWN_LINEAGE_FIELDS"
+
+        parent_hash = lineage.get("parent_hash")
+        history = lineage.get("history", [])
+        if not isinstance(parent_hash, str) or _HASH_RE.fullmatch(parent_hash) is None:
+            return False, "INVALID_PARENT_HASH"
+        if not isinstance(history, list):
+            return False, "INVALID_HISTORY_TYPE"
+        if any(not isinstance(item, str) or _HASH_RE.fullmatch(item) is None for item in history):
+            return False, "INVALID_HISTORY_HASH"
+        if len(history) != len(set(history)):
+            return False, "DUPLICATE_ANCESTOR"
+        if parent_hash in history or candidate_hash in history or candidate_hash == parent_hash:
+            return False, "CIRCULAR_LINEAGE"
+        return True, "LINEAGE_ACYCLIC"
+
+    def _rule_within_resource_limits(
+        self, context: Mapping[str, Any]
+    ) -> Tuple[bool, str]:
+        payload = context["payload"]
+        state_delta = payload.get("state_delta")
+        if not isinstance(state_delta, dict):
+            return False, "INVALID_STATE_DELTA"
+        canonical_delta = _serialize_canonical(
+            state_delta,
+            max_depth=self.max_depth,
+            max_nodes=self.max_nodes,
+        )
+        if len(canonical_delta) > self.max_state_delta_bytes:
+            return False, "STATE_DELTA_TOO_LARGE"
+        return True, "RESOURCE_BOUNDS_VALID"
+
+    def _timestamp(self) -> str:
+        current = self.clock()
+        if current.tzinfo is None:
+            current = current.replace(tzinfo=timezone.utc)
+        return current.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+    def _finalize_receipt(self, receipt: Dict[str, Any]) -> Dict[str, Any]:
+        receipt_bytes = _serialize_canonical(
+            receipt, max_depth=self.max_depth, max_nodes=self.max_nodes
+        )
+        receipt_hash = self.compute_hash(receipt_bytes)
+        signature = self.receipt_signer.sign(receipt_bytes)
+        return {
+            "receipt": receipt,
+            "receipt_hash": receipt_hash,
+            "receipt_signature": signature,
+        }
+
+    def process_payload(self, raw_payload: bytes) -> Dict[str, Any]:
+        raw_hash = (
+            hashlib.sha256(raw_payload).hexdigest()
+            if isinstance(raw_payload, bytes)
+            else None
+        )
+
+        try:
+            payload, canonical_bytes = self.parse_and_canonicalize(raw_payload)
+            candidate_hash = self.compute_hash(canonical_bytes)
+            authorization_hash = self.compute_authorization_hash(payload)
+            admitted, logs = self.evaluate_invariants(
+                payload, candidate_hash, authorization_hash
+            )
+            state = "ADMITTED" if admitted else "REFUSED"
+        except GatekeeperError as error:
+            receipt = {
+                "receipt_version": RECEIPT_VERSION,
+                "gatekeeper_id": self.gatekeeper_id,
+                "canonicalization_version": CANONICALIZATION_VERSION,
+                "rule_set_version": RULE_SET_VERSION,
+                "state": "REFUSED",
+                "evaluated_at": self._timestamp(),
+                "raw_payload_hash": raw_hash,
+                "candidate_hash": None,
+                "authorization_hash": None,
+                "rule_evaluation_logs": [
+                    {
+                        "rule_id": "CANONICALIZATION",
+                        "status": "FAILED",
+                        "detail_code": error.code,
+                    }
+                ],
+            }
+            finalized = self._finalize_receipt(receipt)
+            return {
+                "state": "REFUSED",
+                "candidate_hash": None,
+                "authorization_hash": None,
+                **finalized,
+            }
+
+        receipt = {
+            "receipt_version": RECEIPT_VERSION,
+            "gatekeeper_id": self.gatekeeper_id,
+            "canonicalization_version": CANONICALIZATION_VERSION,
+            "rule_set_version": RULE_SET_VERSION,
+            "state": state,
+            "evaluated_at": self._timestamp(),
+            "raw_payload_hash": raw_hash,
+            "candidate_hash": candidate_hash,
+            "authorization_hash": authorization_hash,
+            "rule_evaluation_logs": logs,
+        }
+        finalized = self._finalize_receipt(receipt)
+        return {
+            "state": state,
+            "candidate_hash": candidate_hash,
+            "authorization_hash": authorization_hash,
+            **finalized,
+        }
+# Nonce: 166272

--- a/tas_logos_gatekeeper.py
+++ b/tas_logos_gatekeeper.py
@@ -247,9 +247,9 @@ class HMACReceiptSigner:
             or signature.get("key_id") != self.key_id
         ):
             return False
-        expected = self.sign(receipt_bytes)["value"]
-        supplied = signature.get("value", "")
-        return hmac.compare_digest(expected, supplied)
+        domain_bound = RECEIPT_DOMAIN.encode("ascii") + b"\x00" + receipt_bytes
+        expected = hmac.new(self._key, domain_bound, hashlib.sha256).hexdigest()
+        return hmac.compare_digest(expected, signature.get("value", ""))
 
 
 class HMACLineageResolver:

--- a/tas_logos_gatekeeper.py.tasmeta.json
+++ b/tas_logos_gatekeeper.py.tasmeta.json
@@ -1,12 +1,12 @@
 {
-  "id": "50e160698cc4b615e285908a37bed9b2ed0a4015ab4e5ce186fb7db8c44b2adc",
+  "id": "5ff4a36d564d25e0fff66aece02fcdfa61f9bae41f1a7135ada37380415e1ea2",
   "type": "TasArtifact",
-  "form_id": "7c36b486de264ac5e1c97ae941574c321558d37257ed995ad703678e41dc8381",
+  "form_id": "49e03284fa4cab94472aad3d7cddec300e360aebcab8a75344b30d834948038b",
   "genome_id": "TAS_GENOME_V1",
-  "lineage_id": "50e160698cc4b615e285908a37bed9b2ed0a4015ab4e5ce186fb7db8c44b2adc",
+  "lineage_id": "5ff4a36d564d25e0fff66aece02fcdfa61f9bae41f1a7135ada37380415e1ea2",
   "h_seed": "Russell Nordland",
-  "cert_id": "d87c101e-7081-4017-a366-7752baef032e",
-  "timestamp": "2026-06-08T01:25:30.212647+00:00",
+  "cert_id": "deedfc78-4217-4eae-bf17-f3855270dade",
+  "timestamp": "2026-07-16T17:19:18.186949+00:00",
   "paradata_trail": [],
   "signatures": [
     {

--- a/tests/test_hardened_logos_gatekeeper.py
+++ b/tests/test_hardened_logos_gatekeeper.py
@@ -1,0 +1,174 @@
+import copy
+import json
+from datetime import datetime, timezone
+
+import pytest
+
+from tas_logos_gatekeeper import (
+    HMACLineageResolver,
+    HMACReceiptSigner,
+    TASLogosGatekeeper,
+    _serialize_canonical,
+)
+
+
+LINEAGE_KEY = b"L" * 32
+RECEIPT_KEY = b"R" * 32
+ZERO_HASH = "0" * 64
+
+
+@pytest.fixture
+def components():
+    fixed_clock = lambda: datetime(2026, 7, 16, 12, 0, 0, tzinfo=timezone.utc)
+    receipt_signer = HMACReceiptSigner("gatekeeper-test", RECEIPT_KEY)
+    resolver = HMACLineageResolver({"steward_01": LINEAGE_KEY})
+    gatekeeper = TASLogosGatekeeper(
+        receipt_signer=receipt_signer,
+        lineage_verifier=resolver.verify,
+        clock=fixed_clock,
+    )
+    return gatekeeper, resolver, receipt_signer
+
+
+def sign_payload(gatekeeper, resolver, payload):
+    unsigned = copy.deepcopy(payload)
+    authorization_hash = gatekeeper.compute_authorization_hash(unsigned)
+    payload["lineage"]["signature"] = resolver.sign(payload, authorization_hash)
+    return payload
+
+
+def base_payload(value=42):
+    return {
+        "credential_id": "steward_01",
+        "operation": "MUTATE_STATE",
+        "state_delta": {"param_x": value},
+        "lineage": {
+            "parent_hash": ZERO_HASH,
+            "history": [],
+        },
+    }
+
+
+def test_syntactic_variation_has_same_candidate_hash(components):
+    gatekeeper, resolver, receipt_signer = components
+    payload = sign_payload(gatekeeper, resolver, base_payload())
+    signature = payload["lineage"]["signature"]
+
+    payload_a = f"""{{
+        "credential_id": "steward_01",
+        "operation": "MUTATE_STATE",
+        "state_delta": {{"param_x": 42.0}},
+        "lineage": {{
+            "parent_hash": "{ZERO_HASH}",
+            "signature": "{signature}",
+            "history": []
+        }}
+    }}""".encode()
+
+    payload_b = f"""{{
+      "state_delta": {{"param_x": 42.00000}},
+      "operation": "MUTATE_STATE",
+      "lineage": {{
+        "signature": "{signature}",
+        "parent_hash": "{ZERO_HASH}",
+        "history": []
+      }},
+      "credential_id": "steward_01"
+    }}""".encode()
+
+    result_a = gatekeeper.process_payload(payload_a)
+    result_b = gatekeeper.process_payload(payload_b)
+
+    assert result_a["state"] == "ADMITTED"
+    assert result_b["state"] == "ADMITTED"
+    assert result_a["candidate_hash"] == result_b["candidate_hash"]
+    assert result_a["authorization_hash"] == result_b["authorization_hash"]
+    assert result_a["receipt"]["raw_payload_hash"] != result_b["receipt"]["raw_payload_hash"]
+    assert receipt_signer.verify(
+        _serialize_canonical(result_a["receipt"]), result_a["receipt_signature"]
+    )
+
+
+def test_missing_signature_is_refused_without_short_circuit(components):
+    gatekeeper, _, _ = components
+    result = gatekeeper.process_payload(json.dumps(base_payload()).encode())
+
+    assert result["state"] == "REFUSED"
+    logs = result["receipt"]["rule_evaluation_logs"]
+    assert [log["rule_id"] for log in logs] == [
+        "INV_01_STRUCTURE",
+        "INV_02_SIGNATURE",
+        "INV_03_LINEAGE_LOOP",
+        "INV_04_RESOURCE_BOUNDS",
+    ]
+    assert logs[1] == {
+        "rule_id": "INV_02_SIGNATURE",
+        "status": "FAILED",
+        "detail_code": "LINEAGE_FIELDS_MISSING",
+    }
+
+
+def test_circular_lineage_is_refused(components):
+    gatekeeper, resolver, _ = components
+    parent = "a" * 64
+    payload = base_payload(10)
+    payload["lineage"]["parent_hash"] = parent
+    payload["lineage"]["history"] = ["b" * 64, parent]
+    sign_payload(gatekeeper, resolver, payload)
+
+    result = gatekeeper.process_payload(_serialize_canonical(payload))
+
+    assert result["state"] == "REFUSED"
+    failure = result["receipt"]["rule_evaluation_logs"][2]
+    assert failure["detail_code"] == "CIRCULAR_LINEAGE"
+
+
+def test_state_delta_over_limit_is_refused(components):
+    gatekeeper, resolver, _ = components
+    payload = base_payload()
+    payload["state_delta"] = {"bloat": "X" * (1024 * 1024 + 100)}
+    sign_payload(gatekeeper, resolver, payload)
+
+    result = gatekeeper.process_payload(_serialize_canonical(payload))
+
+    assert result["state"] == "REFUSED"
+    failure = result["receipt"]["rule_evaluation_logs"][3]
+    assert failure["detail_code"] == "STATE_DELTA_TOO_LARGE"
+
+
+def test_duplicate_key_is_canonicalization_refusal_and_signed(components):
+    gatekeeper, _, receipt_signer = components
+    raw = b'{"credential_id":"first","credential_id":"second"}'
+
+    result = gatekeeper.process_payload(raw)
+
+    assert result["state"] == "REFUSED"
+    assert result["candidate_hash"] is None
+    assert result["receipt"]["rule_evaluation_logs"][0]["detail_code"] == "DUPLICATE_KEY"
+    assert receipt_signer.verify(
+        _serialize_canonical(result["receipt"]), result["receipt_signature"]
+    )
+
+
+def test_non_finite_number_is_refused(components):
+    gatekeeper, _, _ = components
+    result = gatekeeper.process_payload(
+        b'{"credential_id":"steward_01","operation":"MUTATE_STATE",'
+        b'"state_delta":{"x":NaN},"lineage":{"parent_hash":"'
+        + ZERO_HASH.encode()
+        + b'","history":[]}}'
+    )
+    assert result["state"] == "REFUSED"
+    assert result["receipt"]["rule_evaluation_logs"][0]["detail_code"] == "NON_FINITE_NUMBER"
+
+
+def test_same_raw_input_and_fixed_clock_produce_identical_receipt(components):
+    gatekeeper, resolver, _ = components
+    payload = sign_payload(gatekeeper, resolver, base_payload())
+    raw = _serialize_canonical(payload)
+
+    first = gatekeeper.process_payload(raw)
+    second = gatekeeper.process_payload(raw)
+
+    assert first == second
+# Nonce: 11003

--- a/tests/test_hardened_logos_gatekeeper.py.tasmeta.json
+++ b/tests/test_hardened_logos_gatekeeper.py.tasmeta.json
@@ -1,0 +1,18 @@
+{
+  "id": "abfdc003ac10d5c65ded65cb3f15de8d55b6a43d615433cb7661df7a3368baa6",
+  "type": "TasArtifact",
+  "form_id": "704c1b01dadf0665a8b7b883e3dc7e3caca7fff9a6ca3222352e3706707920fb",
+  "genome_id": "TAS_GENOME_V1",
+  "lineage_id": "abfdc003ac10d5c65ded65cb3f15de8d55b6a43d615433cb7661df7a3368baa6",
+  "h_seed": "Russell Nordland",
+  "cert_id": "a92a6389-7177-4322-821d-c0315be0d366",
+  "timestamp": "2026-07-16T17:19:18.186949+00:00",
+  "paradata_trail": [],
+  "signatures": [
+    {
+      "signer": "Russell Nordland",
+      "algorithm": "TAS_HUMAN_SIG_V1",
+      "value": "signed_by_ceremony"
+    }
+  ]
+}


### PR DESCRIPTION
## Purpose

Establish the first Phase 1 Gatekeeper Hardening implementation without advancing disk mutation or commit authorization.

## What changed

- adds strict JSON canonicalization with decimal number normalization and recursively sorted keys
- rejects duplicate keys, non-finite numbers, malformed UTF-8, unsupported roots, unknown fields, malformed lineage hashes, and oversized state deltas
- separates the full `candidate_hash` from the signature-free `authorization_hash`
- evaluates every ordered invariant and records stable detail codes rather than exception text
- replaces `SHA256(receipt || secret)` with domain-separated HMAC-SHA256 receipt authentication
- adds a deterministic HMAC credential resolver for tests and explicitly marks it as non-public-verification infrastructure pending the asymmetric KMS/HSM resolver
- preserves the existing `LogosValidationLoop` API for compatibility
- adds a regression corpus for syntactic equivalence, missing signatures, circular lineage, oversized state, duplicate keys, non-finite numbers, signed refusal receipts, and receipt reproducibility
- resequences the modified and added artifacts with TAS metadata sidecars

## Security corrections to the proposed prototype

The prototype could not be treated as Gate 1 complete because:

1. any non-empty signature placeholder was accepted without cryptographic verification
2. `SHA256(receipt || secret)` was not a proper message-authentication construction
3. duplicate JSON keys and unescaped object keys were not rejected
4. the 1 MiB check occurred only after the entire payload had already been parsed
5. a signed receipt alone did not create append-only immutability
6. the custom serializer was not RFC 8785 and therefore needed its own versioned contract

## Validation

Targeted local validation:

```text
9 passed
```

This includes the pre-existing Logos pipeline tests and the new hardened regression corpus.

## Known blocking edge before Gate 1 can be merged

A hostile JSON value with roughly 10,000 nested arrays can cause CPython's JSON decoder to raise `RecursionError` before the configured canonical depth budget executes. The current draft catches `GatekeeperError`, but not this parser-level exception, so this path can escape without a signed refusal receipt.

Required correction before ready-for-review:

- translate parser `RecursionError` into stable `MAX_DEPTH_EXCEEDED`
- add a regression vector above the decoder recursion boundary
- rerun the targeted suite and repository CI

## Scope boundary

This PR intentionally does **not** implement Gate 2. No state delta may reach disk based on this receipt until the parser-depth blocker is closed, the receipt schema is frozen, and the commit-authorized state machine consumes only a verified `ADMITTED` receipt.
