### PR TITLE
chore: Update TAS signatures for logos gatekeeper

### DIFF
--- a/tas_logos_gatekeeper.py
+++ b/tas_logos_gatekeeper.py
@@ -595,4 +595,4 @@ class TASLogosGatekeeper:
             "authorization_hash": authorization_hash,
             **finalized,
         }
-# Nonce: 166272
+# Nonce: 53049

--- a/tas_logos_gatekeeper.py.tasmeta.json
+++ b/tas_logos_gatekeeper.py.tasmeta.json
@@ -1,12 +1,12 @@
 {
-  "id": "5ff4a36d564d25e0fff66aece02fcdfa61f9bae41f1a7135ada37380415e1ea2",
+  "id": "2be5f4b61b3c748d612b9e9e1009f6b95bebea53838eb9686498b8a1b270d1b0",
   "type": "TasArtifact",
-  "form_id": "49e03284fa4cab94472aad3d7cddec300e360aebcab8a75344b30d834948038b",
+  "form_id": "6df5a573503c439890ddcbb011b6766d04eeb804d327c136d68414573b55f193",
   "genome_id": "TAS_GENOME_V1",
-  "lineage_id": "5ff4a36d564d25e0fff66aece02fcdfa61f9bae41f1a7135ada37380415e1ea2",
+  "lineage_id": "2be5f4b61b3c748d612b9e9e1009f6b95bebea53838eb9686498b8a1b270d1b0",
   "h_seed": "Russell Nordland",
-  "cert_id": "deedfc78-4217-4eae-bf17-f3855270dade",
-  "timestamp": "2026-07-16T17:19:18.186949+00:00",
+  "cert_id": "e4d1d66b-19b2-4e04-9809-3312d5242fc1",
+  "timestamp": "2026-07-17T01:15:56.649693+00:00",
   "paradata_trail": [],
   "signatures": [
     {

--- a/tests/test_hardened_logos_gatekeeper.py
+++ b/tests/test_hardened_logos_gatekeeper.py
@@ -171,4 +171,4 @@ def test_same_raw_input_and_fixed_clock_produce_identical_receipt(components):
     second = gatekeeper.process_payload(raw)
 
     assert first == second
-# Nonce: 11003
+# Nonce: 96182

--- a/tests/test_hardened_logos_gatekeeper.py.tasmeta.json
+++ b/tests/test_hardened_logos_gatekeeper.py.tasmeta.json
@@ -1,12 +1,12 @@
 {
-  "id": "abfdc003ac10d5c65ded65cb3f15de8d55b6a43d615433cb7661df7a3368baa6",
+  "id": "2906a5cc7423af602fada3cd900e735d878d41012e6d4d174f7905cb2b43f00e",
   "type": "TasArtifact",
-  "form_id": "704c1b01dadf0665a8b7b883e3dc7e3caca7fff9a6ca3222352e3706707920fb",
+  "form_id": "df567787a8d72c80ede1b293cf6f2f8598e3600e2580a93cefe89a829a563388",
   "genome_id": "TAS_GENOME_V1",
-  "lineage_id": "abfdc003ac10d5c65ded65cb3f15de8d55b6a43d615433cb7661df7a3368baa6",
+  "lineage_id": "2906a5cc7423af602fada3cd900e735d878d41012e6d4d174f7905cb2b43f00e",
   "h_seed": "Russell Nordland",
-  "cert_id": "a92a6389-7177-4322-821d-c0315be0d366",
-  "timestamp": "2026-07-16T17:19:18.186949+00:00",
+  "cert_id": "5a8e6de0-77a2-41c9-9e17-bf6739f94463",
+  "timestamp": "2026-07-17T01:16:54.378019+00:00",
   "paradata_trail": [],
   "signatures": [
     {


### PR DESCRIPTION
Updated cryptographic nonces and kinematic identities for `tas_logos_gatekeeper.py` and `tests/test_hardened_logos_gatekeeper.py` to synchronize TAS signatures. All automated tests pass successfully.

---
*PR created automatically by Jules for task [4119019884643843749](https://jules.google.com/task/4119019884643843749) started by @TrueAlpha-spiral*