### PR TITLE
Harden gatekeeper canonicalization and ingress handling

### DIFF
--- a/tas_logos_gatekeeper.py
+++ b/tas_logos_gatekeeper.py
@@ -153,23 +153,41 @@ def _validate_text(value: str) -> None:
 
 
 def _canonical_decimal(value: decimal.Decimal) -> bytes:
+    """Render a finite Decimal exactly, independently of the active context."""
     if not value.is_finite():
         raise GatekeeperError("NON_FINITE_NUMBER", "Non-finite numbers are forbidden.")
 
-    if value.is_zero():
+    sign, coefficient, exponent = value.as_tuple()
+    if not any(coefficient):
         return b"0"
 
-    digits = len(value.as_tuple().digits)
-    adjusted = value.adjusted()
-    if digits > 128 or abs(adjusted) > 308:
+    # Remove only insignificant trailing coefficient zeros.  Unlike normalize(),
+    # this does not round according to decimal.getcontext().prec.
+    digits = list(coefficient)
+    while digits[-1] == 0:
+        digits.pop()
+        exponent += 1
+
+    significant_digits = len(digits)
+    adjusted = exponent + significant_digits - 1
+    if significant_digits > 128 or abs(adjusted) > 308:
         raise GatekeeperError("NUMBER_OUT_OF_RANGE", "Number exceeds canonical numeric bounds.")
 
-    normalized = value.normalize()
-    rendered = format(normalized, "f")
-    if "." in rendered:
-        rendered = rendered.rstrip("0").rstrip(".")
-    if rendered == "-0":
-        rendered = "0"
+    coefficient_text = "".join(str(digit) for digit in digits)
+    if exponent >= 0:
+        rendered = coefficient_text + ("0" * exponent)
+    else:
+        decimal_point = len(coefficient_text) + exponent
+        if decimal_point > 0:
+            rendered = (
+                coefficient_text[:decimal_point]
+                + "."
+                + coefficient_text[decimal_point:]
+            )
+        else:
+            rendered = "0." + ("0" * -decimal_point) + coefficient_text
+    if sign:
+        rendered = "-" + rendered
     return rendered.encode("ascii")
 
 
@@ -368,6 +386,10 @@ class TASLogosGatekeeper:
             )
         except GatekeeperError:
             raise
+        except RecursionError as exc:
+            raise GatekeeperError(
+                "MAX_DEPTH_EXCEEDED", "JSON nesting exceeds the configured limit."
+            ) from exc
         except (json.JSONDecodeError, decimal.InvalidOperation, ValueError) as exc:
             raise GatekeeperError("MALFORMED_JSON", "Payload is not valid strict JSON.") from exc
 
@@ -550,30 +572,16 @@ class TASLogosGatekeeper:
             )
             state = "ADMITTED" if admitted else "REFUSED"
         except GatekeeperError as error:
-            receipt = {
-                "receipt_version": RECEIPT_VERSION,
-                "gatekeeper_id": self.gatekeeper_id,
-                "canonicalization_version": CANONICALIZATION_VERSION,
-                "rule_set_version": RULE_SET_VERSION,
-                "state": "REFUSED",
-                "evaluated_at": self._timestamp(),
-                "raw_payload_hash": raw_hash,
-                "candidate_hash": None,
-                "authorization_hash": None,
-                "rule_evaluation_logs": [
-                    {
-                        "rule_id": "CANONICALIZATION",
-                        "status": "FAILED",
-                        "detail_code": error.code,
-                    }
-                ],
-            }
-            finalized = self._finalize_receipt(receipt)
+            # Canonicalization failures are malformed ingress, not evaluated
+            # transitions.  Keep them outside the signed receipt pipeline so an
+            # unauthenticated sender cannot turn invalid transport into durable
+            # constitutional evidence.
             return {
-                "state": "REFUSED",
+                "state": "INGRESS_REJECTED",
                 "candidate_hash": None,
                 "authorization_hash": None,
-                **finalized,
+                "raw_payload_hash": raw_hash,
+                "error_code": error.code,
             }
 
         receipt = {

--- a/tests/test_hardened_logos_gatekeeper.py
+++ b/tests/test_hardened_logos_gatekeeper.py
@@ -1,4 +1,5 @@
 import copy
+import decimal
 import json
 from datetime import datetime, timezone
 
@@ -136,18 +137,16 @@ def test_state_delta_over_limit_is_refused(components):
     assert failure["detail_code"] == "STATE_DELTA_TOO_LARGE"
 
 
-def test_duplicate_key_is_canonicalization_refusal_and_signed(components):
-    gatekeeper, _, receipt_signer = components
+def test_duplicate_key_is_ingress_rejected_without_a_signed_receipt(components):
+    gatekeeper, _, _ = components
     raw = b'{"credential_id":"first","credential_id":"second"}'
 
     result = gatekeeper.process_payload(raw)
 
-    assert result["state"] == "REFUSED"
+    assert result["state"] == "INGRESS_REJECTED"
     assert result["candidate_hash"] is None
-    assert result["receipt"]["rule_evaluation_logs"][0]["detail_code"] == "DUPLICATE_KEY"
-    assert receipt_signer.verify(
-        _serialize_canonical(result["receipt"]), result["receipt_signature"]
-    )
+    assert result["error_code"] == "DUPLICATE_KEY"
+    assert "receipt" not in result
 
 
 def test_non_finite_number_is_refused(components):
@@ -158,8 +157,41 @@ def test_non_finite_number_is_refused(components):
         + ZERO_HASH.encode()
         + b'","history":[]}}'
     )
-    assert result["state"] == "REFUSED"
-    assert result["receipt"]["rule_evaluation_logs"][0]["detail_code"] == "NON_FINITE_NUMBER"
+    assert result["state"] == "INGRESS_REJECTED"
+    assert result["error_code"] == "NON_FINITE_NUMBER"
+
+
+@pytest.mark.parametrize(
+    ("source", "expected"),
+    [
+        ("12345678901234567890123456789", "12345678901234567890123456789"),
+        ("9" * 128, "9" * 128),
+        ("1234567890123456789012345678900", "1234567890123456789012345678900"),
+        ("0.00000000000000000000000000012345678901234567890123456789", "0.00000000000000000000000000012345678901234567890123456789"),
+    ],
+)
+def test_decimal_canonicalization_is_exact_outside_ambient_precision(source, expected):
+    original_context = decimal.getcontext().copy()
+    try:
+        decimal.getcontext().prec = 28
+        assert _serialize_canonical(decimal.Decimal(source)) == expected.encode("ascii")
+    finally:
+        decimal.setcontext(original_context)
+
+
+def test_hostile_json_nesting_is_a_bounded_ingress_rejection(components):
+    gatekeeper, _, _ = components
+    raw = b'{"x":' + (b"[" * 2_000) + b"0" + (b"]" * 2_000) + b"}"
+
+    result = gatekeeper.process_payload(raw)
+
+    assert result == {
+        "state": "INGRESS_REJECTED",
+        "candidate_hash": None,
+        "authorization_hash": None,
+        "raw_payload_hash": gatekeeper.compute_hash(raw),
+        "error_code": "MAX_DEPTH_EXCEEDED",
+    }
 
 
 def test_same_raw_input_and_fixed_clock_produce_identical_receipt(components):


### PR DESCRIPTION
### Motivation

- Prevent ambient `decimal` context from influencing canonical numeric rendering so candidate and authorization hashes are stable and unambiguous.  
- Ensure deeply nested or malicious JSON payloads do not escape the canonicalization error path and produce uncontrolled exceptions.  
- Keep malformed transport from being turned into signed constitutional evidence by separating ingress rejection from the signed receipt pipeline.  

### Description

- Replace context-dependent `Decimal.normalize()` rendering with exact tuple-based rendering using `Decimal.as_tuple()` and reconstruct numeric ASCII bytes without rounding, preserving bounds checks for significant digits and exponent limits in `tas_logos_gatekeeper.py`.  
- Treat `RecursionError` raised by `json.loads()` as a bounded `GatekeeperError(

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5981abd28c83339386ead662d1eec3)