### PR TITLE
Optimize decimal canonicalization trimming

### DIFF
--- a/tas_logos_gatekeeper.py
+++ b/tas_logos_gatekeeper.py
@@ -163,17 +163,24 @@ def _canonical_decimal(value: decimal.Decimal) -> bytes:
 
     # Remove only insignificant trailing coefficient zeros.  Unlike normalize(),
     # this does not round according to decimal.getcontext().prec.
-    digits = list(coefficient)
-    while digits[-1] == 0:
-        digits.pop()
-        exponent += 1
+    trailing_zeros = 0
+    for digit in reversed(coefficient):
+        if digit != 0:
+            break
+        trailing_zeros += 1
+
+    if trailing_zeros:
+        digits = list(coefficient[:-trailing_zeros])
+        exponent += trailing_zeros
+    else:
+        digits = list(coefficient)
 
     significant_digits = len(digits)
     adjusted = exponent + significant_digits - 1
     if significant_digits > 128 or abs(adjusted) > 308:
         raise GatekeeperError("NUMBER_OUT_OF_RANGE", "Number exceeds canonical numeric bounds.")
 
-    coefficient_text = "".join(str(digit) for digit in digits)
+    coefficient_text = "".join([str(digit) for digit in digits])
     if exponent >= 0:
         rendered = coefficient_text + ("0" * exponent)
     else:


### PR DESCRIPTION
### Motivation
- Improve performance and clarity of the canonical Decimal renderer by avoiding repeated list mutation when trimming trailing zeros from large coefficient tuples.
- Apply a minor readability change to coefficient rendering to match review guidance while preserving exact canonical numeric semantics.

### Description
- Replace repeated `pop()` trimming with a suffix-scan that counts trailing zeros and slices the coefficient once, and update `exponent` accordingly in `_canonical_decimal`.
- Use a list comprehension inside `"".join(...)` for `coefficient_text` construction to make the intent explicit.
- Preserve all existing numeric bounds checks and canonicalization behavior, including the `GatekeeperError` conditions.

### Testing
- Ran the project test suite with `PYTHONPATH=$(pwd)/tas_pythonetics/src:$(pwd)/tas-recursion-conversion:$(pwd) pytest`, which resulted in `185 passed, 2 skipped`.
- Ran `git diff --check` with no issues reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5c2524fed083339a4262c554b1b37c)