### PR TITLE
Add Layer 1 SMT-based policy verifier (Z3) with tests

### DIFF
--- a/tas_pythonetics/pyproject.toml
+++ b/tas_pythonetics/pyproject.toml
@@ -5,3 +5,4 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "tas_pythonetics"
 version = "0.1.0"
+dependencies = ["z3-solver>=4.12"]

--- a/tas_pythonetics/src/tas_pythonetics/__init__.py
+++ b/tas_pythonetics/src/tas_pythonetics/__init__.py
@@ -15,6 +15,13 @@ from .layer1_policy import (
     Layer1PolicyVerifier,
     Layer1State,
 )
+from .layer0_governance import (
+    ActionPayload,
+    DelegationCertificate,
+    Layer0GovernanceEngine,
+    SignaturePayload,
+    canonical_hash,
+)
 __all__ = [
     "recursive_truth_amplify",
     "TAS_recursive_authenticate",
@@ -23,4 +30,9 @@ __all__ = [
     "Layer1Action",
     "Layer1PolicyVerifier",
     "Layer1State",
+    "ActionPayload",
+    "DelegationCertificate",
+    "Layer0GovernanceEngine",
+    "SignaturePayload",
+    "canonical_hash",
 ]

--- a/tas_pythonetics/src/tas_pythonetics/__init__.py
+++ b/tas_pythonetics/src/tas_pythonetics/__init__.py
@@ -10,9 +10,17 @@ from .drift_detection import (
     detect_drift,
     initiate_self_heal,
 )
+from .layer1_policy import (
+    Layer1Action,
+    Layer1PolicyVerifier,
+    Layer1State,
+)
 __all__ = [
     "recursive_truth_amplify",
     "TAS_recursive_authenticate",
     "detect_drift",
     "initiate_self_heal",
+    "Layer1Action",
+    "Layer1PolicyVerifier",
+    "Layer1State",
 ]

--- a/tas_pythonetics/src/tas_pythonetics/layer0_governance.py
+++ b/tas_pythonetics/src/tas_pythonetics/layer0_governance.py
@@ -1,0 +1,229 @@
+"""Layer 0 weighted quorum, delegation, and emergency revocation primitives.
+
+Layer 0 is the package's root-of-trust simulation layer.  It intentionally uses
+standard-library hashing for deterministic tests while keeping the interfaces
+shaped like production cryptographic verification points.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Dict, List, Optional, Set, Tuple
+
+
+def canonical_hash(data: dict) -> str:
+    """Return a deterministic SHA-256 hash of canonicalized JSON data."""
+    canonical_json = json.dumps(data, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical_json.encode("utf-8")).hexdigest()
+
+
+@dataclass(frozen=True)
+class SignaturePayload:
+    """A signature bound to a validator or delegated key identifier."""
+
+    key_id: str
+    signature: str
+
+
+@dataclass
+class DelegationCertificate:
+    """Capability-bounded delegation certificate for Layer 0 identity chains."""
+
+    certificate_id: str
+    delegator_key_id: str
+    delegate_key_id: str
+    capabilities: List[str]
+    delegation_depth: int
+    weight_cap: int
+    valid_from: str
+    valid_until: str
+    nonce: str
+    signature: Optional[str] = None
+
+    def to_dict(self) -> dict:
+        """Return a deterministic certificate body, excluding the signature."""
+        return {
+            "certificate_id": self.certificate_id,
+            "delegator_key_id": self.delegator_key_id,
+            "delegate_key_id": self.delegate_key_id,
+            "capabilities": sorted(self.capabilities),
+            "delegation_depth": self.delegation_depth,
+            "weight_cap": self.weight_cap,
+            "valid_from": self.valid_from,
+            "valid_until": self.valid_until,
+            "nonce": self.nonce,
+        }
+
+
+@dataclass
+class ActionPayload:
+    """Canonical action body plus direct signatures or a delegation chain."""
+
+    action_id: str
+    capability_requested: str
+    payload_data: dict
+    signatures: List[SignaturePayload]
+    delegation_chain: List[DelegationCertificate] = field(default_factory=list)
+
+    def get_canonical_bytes(self) -> bytes:
+        """Return action bytes used for signature verification."""
+        body = {
+            "action_id": self.action_id,
+            "capability_requested": self.capability_requested,
+            "payload_data": self.payload_data,
+        }
+        return json.dumps(body, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+class Layer0GovernanceEngine:
+    """Evaluate Layer 0 authorization, delegation, and emergency purges."""
+
+    def __init__(self, threshold: int, validators: Dict[str, dict]) -> None:
+        if threshold < 1:
+            raise ValueError("threshold must be positive")
+        self.threshold = threshold
+        self.validators = validators
+        self.revocation_list: Set[str] = set()
+
+    def verify_action_authorization(self, action: ActionPayload) -> Tuple[bool, str]:
+        """Evaluate action authorization via delegation or weighted root quorum."""
+        payload_bytes = action.get_canonical_bytes()
+
+        if action.delegation_chain:
+            return self._verify_delegated_action(action, payload_bytes)
+
+        accumulated_weight = 0
+        seen_signers: Set[str] = set()
+        remaining_weight = self._active_weight()
+
+        for sig in action.signatures:
+            if sig.key_id in seen_signers:
+                continue
+            seen_signers.add(sig.key_id)
+
+            validator = self.validators.get(sig.key_id)
+            if sig.key_id in self.revocation_list or validator is None:
+                continue
+
+            remaining_weight -= validator["weight"]
+            if self._verify_mock_signature(sig.key_id, payload_bytes, sig.signature):
+                accumulated_weight += validator["weight"]
+
+            if accumulated_weight >= self.threshold:
+                return True, f"Quorum satisfied ({accumulated_weight} >= {self.threshold})."
+            if accumulated_weight + remaining_weight < self.threshold:
+                break
+
+        return False, f"Quorum threshold not met ({accumulated_weight} < {self.threshold})."
+
+    def validate_delegation_chain(
+        self, chain: List[DelegationCertificate], requested_capability: str
+    ) -> Tuple[bool, str]:
+        """Validate capability attenuation, depth boundaries, and time windows."""
+        if not chain:
+            return False, "Chain is empty."
+
+        now = datetime.now(timezone.utc)
+        root_cert = chain[0]
+        root_validator = self.validators.get(root_cert.delegator_key_id)
+
+        if root_cert.delegator_key_id in self.revocation_list:
+            return False, f"Root delegator {root_cert.delegator_key_id} is revoked."
+        if root_validator is None:
+            return False, f"Root delegator {root_cert.delegator_key_id} is not an active validator."
+
+        parent_capabilities = set(root_validator["capabilities"])
+        parent_depth = 3
+        parent_valid_until: Optional[datetime] = None
+
+        for idx, cert in enumerate(chain):
+            if cert.delegate_key_id in self.revocation_list:
+                return False, f"Key {cert.delegate_key_id} in chain is revoked."
+
+            from_dt = datetime.fromisoformat(cert.valid_from)
+            until_dt = datetime.fromisoformat(cert.valid_until)
+            if not (from_dt <= now <= until_dt):
+                return False, f"Certificate {cert.certificate_id} is outside its validity window."
+            if parent_valid_until is not None and until_dt > parent_valid_until:
+                return False, f"Temporal enclosure violated at step {idx}."
+            if cert.delegation_depth >= parent_depth:
+                return False, f"Delegation depth violated at step {idx} ({cert.delegation_depth} >= {parent_depth})."
+            if cert.weight_cap < 1:
+                return False, f"Weight cap violated at step {idx}."
+
+            cert_capabilities = set(cert.capabilities)
+            if not cert_capabilities.issubset(parent_capabilities):
+                return False, f"Capability expansion attempt detected at step {idx}."
+
+            parent_capabilities = cert_capabilities
+            parent_depth = cert.delegation_depth
+            parent_valid_until = until_dt
+
+        if requested_capability not in parent_capabilities:
+            return False, f"Requested capability '{requested_capability}' not granted to leaf delegate."
+
+        return True, "Chain valid."
+
+    def execute_emergency_purge(self, target_key_id: str, endorsement_votes: Dict[str, str]) -> Tuple[bool, str]:
+        """Evict a key when endorsements satisfy the 66% emergency threshold."""
+        if target_key_id in self.revocation_list:
+            return False, f"Key {target_key_id} is already revoked."
+        if target_key_id not in self.validators:
+            return False, f"Key {target_key_id} is not an active validator."
+
+        total_active_weight = self._active_weight()
+        emergency_threshold = int(0.66 * total_active_weight) + 1
+        accumulated_vote_weight = 0
+        seen_voters: Set[str] = set()
+        purge_payload = f"PURGE_EVICTION_{target_key_id}".encode()
+
+        for voter_id, sig in endorsement_votes.items():
+            if voter_id in seen_voters:
+                continue
+            seen_voters.add(voter_id)
+            if voter_id in self.revocation_list or voter_id not in self.validators:
+                continue
+            if voter_id == target_key_id:
+                continue
+            if self._verify_mock_signature(voter_id, purge_payload, sig):
+                accumulated_vote_weight += self.validators[voter_id]["weight"]
+
+        if accumulated_vote_weight < emergency_threshold:
+            return False, f"Emergency purge failed ({accumulated_vote_weight} < {emergency_threshold})."
+
+        self.revocation_list.add(target_key_id)
+        remaining_active_weight = self._active_weight()
+        self.threshold = max(1, int(remaining_active_weight * 0.60))
+        return True, (
+            f"Eviction successful! Key {target_key_id} revoked. "
+            f"New active total weight: {remaining_active_weight}, Re-balanced threshold: {self.threshold}"
+        )
+
+    def _verify_delegated_action(self, action: ActionPayload, payload_bytes: bytes) -> Tuple[bool, str]:
+        valid_chain, chain_msg = self.validate_delegation_chain(
+            action.delegation_chain, action.capability_requested
+        )
+        if not valid_chain:
+            return False, f"Delegation chain invalid: {chain_msg}"
+
+        leaf_cert = action.delegation_chain[-1]
+        delegate_sig = next((s for s in action.signatures if s.key_id == leaf_cert.delegate_key_id), None)
+        if delegate_sig is None:
+            return False, "Missing signature from leaf delegate identity."
+        if leaf_cert.delegate_key_id in self.revocation_list:
+            return False, f"Delegate key {leaf_cert.delegate_key_id} is revoked."
+        if not self._verify_mock_signature(leaf_cert.delegate_key_id, payload_bytes, delegate_sig.signature):
+            return False, "Invalid signature for leaf delegate key."
+
+        return True, "Delegated action authorized successfully."
+
+    def _active_weight(self) -> int:
+        return sum(v["weight"] for k, v in self.validators.items() if k not in self.revocation_list)
+
+    @staticmethod
+    def _verify_mock_signature(key_id: str, payload_bytes: bytes, signature: str) -> bool:
+        expected = hashlib.sha256(key_id.encode() + payload_bytes).hexdigest()
+        return signature == expected

--- a/tas_pythonetics/src/tas_pythonetics/layer1_policy.py
+++ b/tas_pythonetics/src/tas_pythonetics/layer1_policy.py
@@ -1,0 +1,135 @@
+"""Stateful Layer 1 policy verification using Z3 SMT constraints.
+
+The verifier models policy enforcement as a state transition proof instead of
+approving actions in isolation.  A candidate action is admissible only when Z3
+can prove that the successor state cannot violate the Layer 1 invariant.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Tuple
+
+from z3 import And, BitVec, BitVecVal, If, Int, Not, Solver, sat, unsat
+
+
+@dataclass(frozen=True)
+class Layer1State:
+    """Materialized policy state for a TAS session."""
+
+    clearance: int
+    max_data_class: int
+    entropy_budget: int
+    capability_mask: int = 0
+
+
+@dataclass(frozen=True)
+class Layer1Action:
+    """Symbolic resource demands for a proposed action."""
+
+    req_level: int
+    entropy_cost: int
+    req_mask: int = 0
+
+
+class Layer1PolicyVerifier:
+    """Verify TAS Layer 1 state transitions against global invariants."""
+
+    def __init__(self, *, mask_width: int = 64) -> None:
+        self.mask_width = mask_width
+        self.solver = Solver()
+
+        # State vector at t (S_t)
+        self.clearance_t = Int("clearance_t")
+        self.max_data_class_t = Int("max_data_class_t")
+        self.entropy_budget_t = Int("entropy_budget_t")
+        self.capability_mask_t = BitVec("capability_mask_t", mask_width)
+
+        # State vector at t+1 (S_{t+1})
+        self.clearance_t1 = Int("clearance_t1")
+        self.max_data_class_t1 = Int("max_data_class_t1")
+        self.entropy_budget_t1 = Int("entropy_budget_t1")
+        self.capability_mask_t1 = BitVec("capability_mask_t1", mask_width)
+
+        # Action parameters (a_t)
+        self.req_level = Int("req_level")
+        self.entropy_cost = Int("entropy_cost")
+        self.req_mask = BitVec("req_mask", mask_width)
+
+    def _invariant(self, clearance, data_class, entropy_budget, capability_mask, req_mask):
+        """Global safety predicate Phi(S)."""
+        return And(
+            clearance >= 0,
+            data_class >= 0,
+            entropy_budget >= 0,
+            data_class <= clearance,
+            (capability_mask & req_mask) == req_mask,
+        )
+
+    def verify_action(self, current_state: Layer1State | dict, action: Layer1Action | dict) -> Tuple[bool, str]:
+        """Return whether the proposed transition preserves Layer 1 invariants."""
+        state = self._coerce_state(current_state)
+        candidate = self._coerce_action(action)
+        self.solver.reset()
+
+        self.solver.add(self.clearance_t == state.clearance)
+        self.solver.add(self.max_data_class_t == state.max_data_class)
+        self.solver.add(self.entropy_budget_t == state.entropy_budget)
+        self.solver.add(self.capability_mask_t == BitVecVal(state.capability_mask, self.mask_width))
+
+        self.solver.add(self.req_level == candidate.req_level)
+        self.solver.add(self.entropy_cost == candidate.entropy_cost)
+        self.solver.add(self.req_mask == BitVecVal(candidate.req_mask, self.mask_width))
+
+        self.solver.add(
+            self._invariant(
+                self.clearance_t,
+                self.max_data_class_t,
+                self.entropy_budget_t,
+                self.capability_mask_t,
+                self.req_mask,
+            )
+        )
+        if self.solver.check() != sat:
+            return False, "Current state or requested capability fails Layer 1 preconditions."
+
+        self.solver.add(self.clearance_t1 == self.clearance_t)
+        self.solver.add(
+            self.max_data_class_t1
+            == If(self.req_level > self.max_data_class_t, self.req_level, self.max_data_class_t)
+        )
+        self.solver.add(self.entropy_budget_t1 == self.entropy_budget_t - self.entropy_cost)
+        self.solver.add(self.capability_mask_t1 == self.capability_mask_t)
+
+        self.solver.add(
+            Not(
+                self._invariant(
+                    self.clearance_t1,
+                    self.max_data_class_t1,
+                    self.entropy_budget_t1,
+                    self.capability_mask_t1,
+                    self.req_mask,
+                )
+            )
+        )
+
+        result = self.solver.check()
+        if result == unsat:
+            return True, "State transition satisfies all Layer 1 invariants."
+
+        model = self.solver.model()
+        return (
+            False,
+            "Semantic Boundary Leak Detected! "
+            f"S_{{t+1}} state violation: max_data_class={model[self.max_data_class_t1]}, "
+            f"entropy_budget={model[self.entropy_budget_t1]}, "
+            f"capability_mask={model[self.capability_mask_t1]}",
+        )
+
+    @staticmethod
+    def _coerce_state(value: Layer1State | dict) -> Layer1State:
+        return value if isinstance(value, Layer1State) else Layer1State(**value)
+
+    @staticmethod
+    def _coerce_action(value: Layer1Action | dict) -> Layer1Action:
+        return value if isinstance(value, Layer1Action) else Layer1Action(**value)

--- a/tas_pythonetics/tests/test_layer0_governance.py
+++ b/tas_pythonetics/tests/test_layer0_governance.py
@@ -1,0 +1,181 @@
+import hashlib
+from datetime import datetime, timedelta, timezone
+
+from tas_pythonetics.layer0_governance import (
+    ActionPayload,
+    DelegationCertificate,
+    Layer0GovernanceEngine,
+    SignaturePayload,
+    canonical_hash,
+)
+
+
+def make_sig(key_id: str, payload_bytes: bytes) -> SignaturePayload:
+    signature = hashlib.sha256(key_id.encode() + payload_bytes).hexdigest()
+    return SignaturePayload(key_id=key_id, signature=signature)
+
+
+def make_engine() -> Layer0GovernanceEngine:
+    validators = {
+        "val_A": {"weight": 3, "capabilities": {"sys:write", "sys:read", "policy:mutate"}},
+        "val_B": {"weight": 3, "capabilities": {"sys:write", "sys:read"}},
+        "val_C": {"weight": 2, "capabilities": {"sys:read"}},
+        "val_D": {"weight": 2, "capabilities": {"sys:read"}},
+    }
+    return Layer0GovernanceEngine(threshold=6, validators=validators)
+
+
+def test_canonical_hash_is_order_stable():
+    assert canonical_hash({"b": 2, "a": 1}) == canonical_hash({"a": 1, "b": 2})
+
+
+def test_quorum_success():
+    engine = make_engine()
+    action = ActionPayload("act_1", "sys:write", {"data": "test"}, signatures=[])
+    payload_bytes = action.get_canonical_bytes()
+    action.signatures = [make_sig("val_A", payload_bytes), make_sig("val_B", payload_bytes)]
+
+    authorized, msg = engine.verify_action_authorization(action)
+
+    assert authorized is True
+    assert "Quorum satisfied" in msg
+
+
+def test_quorum_failure_insufficient_weight():
+    engine = make_engine()
+    action = ActionPayload("act_2", "sys:read", {"data": "test"}, signatures=[])
+    payload_bytes = action.get_canonical_bytes()
+    action.signatures = [make_sig("val_C", payload_bytes), make_sig("val_D", payload_bytes)]
+
+    authorized, msg = engine.verify_action_authorization(action)
+
+    assert authorized is False
+    assert "Quorum threshold not met" in msg
+
+
+def test_delegation_valid_attenuation():
+    engine = make_engine()
+    now = datetime.now(timezone.utc)
+    cert = DelegationCertificate(
+        certificate_id="cert_001",
+        delegator_key_id="val_A",
+        delegate_key_id="agent_leaf",
+        capabilities=["sys:read"],
+        delegation_depth=2,
+        weight_cap=1,
+        valid_from=(now - timedelta(minutes=5)).isoformat(),
+        valid_until=(now + timedelta(hours=1)).isoformat(),
+        nonce="nonce_123",
+    )
+    action = ActionPayload("act_del_1", "sys:read", {"op": "query"}, signatures=[], delegation_chain=[cert])
+    action.signatures = [make_sig("agent_leaf", action.get_canonical_bytes())]
+
+    authorized, msg = engine.verify_action_authorization(action)
+
+    assert authorized is True
+    assert "Delegated action authorized" in msg
+
+
+def test_delegation_failure_capability_expansion():
+    engine = make_engine()
+    now = datetime.now(timezone.utc)
+    cert = DelegationCertificate(
+        certificate_id="cert_invalid",
+        delegator_key_id="val_C",
+        delegate_key_id="agent_rogue",
+        capabilities=["sys:read", "policy:mutate"],
+        delegation_depth=1,
+        weight_cap=1,
+        valid_from=(now - timedelta(minutes=5)).isoformat(),
+        valid_until=(now + timedelta(hours=1)).isoformat(),
+        nonce="nonce_456",
+    )
+    action = ActionPayload("act_del_2", "policy:mutate", {"op": "nuke"}, signatures=[], delegation_chain=[cert])
+    action.signatures = [make_sig("agent_rogue", action.get_canonical_bytes())]
+
+    authorized, msg = engine.verify_action_authorization(action)
+
+    assert authorized is False
+    assert "Capability expansion attempt detected" in msg
+
+
+def test_delegation_failure_depth_exceeded():
+    engine = make_engine()
+    now = datetime.now(timezone.utc)
+    cert = DelegationCertificate(
+        certificate_id="cert_depth_err",
+        delegator_key_id="val_A",
+        delegate_key_id="agent_deep",
+        capabilities=["sys:read"],
+        delegation_depth=3,
+        weight_cap=1,
+        valid_from=(now - timedelta(minutes=5)).isoformat(),
+        valid_until=(now + timedelta(hours=1)).isoformat(),
+        nonce="nonce_789",
+    )
+    action = ActionPayload("act_del_3", "sys:read", {}, signatures=[], delegation_chain=[cert])
+    action.signatures = [make_sig("agent_deep", action.get_canonical_bytes())]
+
+    authorized, msg = engine.verify_action_authorization(action)
+
+    assert authorized is False
+    assert "Delegation depth violated" in msg
+
+
+def test_delegation_failure_temporal_expansion():
+    engine = make_engine()
+    now = datetime.now(timezone.utc)
+    parent = DelegationCertificate(
+        certificate_id="cert_parent",
+        delegator_key_id="val_A",
+        delegate_key_id="agent_mid",
+        capabilities=["sys:read"],
+        delegation_depth=2,
+        weight_cap=1,
+        valid_from=(now - timedelta(minutes=5)).isoformat(),
+        valid_until=(now + timedelta(minutes=30)).isoformat(),
+        nonce="nonce_parent",
+    )
+    child = DelegationCertificate(
+        certificate_id="cert_child",
+        delegator_key_id="agent_mid",
+        delegate_key_id="agent_leaf",
+        capabilities=["sys:read"],
+        delegation_depth=1,
+        weight_cap=1,
+        valid_from=(now - timedelta(minutes=1)).isoformat(),
+        valid_until=(now + timedelta(hours=1)).isoformat(),
+        nonce="nonce_child",
+    )
+
+    valid, msg = engine.validate_delegation_chain([parent, child], "sys:read")
+
+    assert valid is False
+    assert "Temporal enclosure violated" in msg
+
+
+def test_emergency_key_eviction_cycle():
+    engine = make_engine()
+    target_key = "val_B"
+    purge_bytes = f"PURGE_EVICTION_{target_key}".encode()
+    votes = {
+        "val_A": hashlib.sha256("val_A".encode() + purge_bytes).hexdigest(),
+        "val_C": hashlib.sha256("val_C".encode() + purge_bytes).hexdigest(),
+        "val_D": hashlib.sha256("val_D".encode() + purge_bytes).hexdigest(),
+    }
+
+    purged, purge_msg = engine.execute_emergency_purge(target_key, votes)
+
+    assert purged is True
+    assert "Eviction successful" in purge_msg
+    assert target_key in engine.revocation_list
+    assert engine.threshold == 4
+
+    action = ActionPayload("act_evicted", "sys:write", {}, signatures=[])
+    payload_bytes = action.get_canonical_bytes()
+    action.signatures = [make_sig("val_B", payload_bytes), make_sig("val_C", payload_bytes)]
+
+    authorized, msg = engine.verify_action_authorization(action)
+
+    assert authorized is False
+    assert "Quorum threshold not met" in msg

--- a/tas_pythonetics/tests/test_layer1_policy.py
+++ b/tas_pythonetics/tests/test_layer1_policy.py
@@ -1,0 +1,46 @@
+from tas_pythonetics.layer1_policy import Layer1Action, Layer1PolicyVerifier, Layer1State
+
+
+def test_valid_transition_preserves_invariants():
+    verifier = Layer1PolicyVerifier()
+    state = Layer1State(clearance=3, max_data_class=1, entropy_budget=10, capability_mask=0b111)
+    action = Layer1Action(req_level=2, entropy_cost=4, req_mask=0b010)
+
+    is_valid, message = verifier.verify_action(state, action)
+
+    assert is_valid is True
+    assert "satisfies" in message
+
+
+def test_entropy_exhaustion_is_rejected():
+    verifier = Layer1PolicyVerifier()
+    state = {"clearance": 3, "max_data_class": 1, "entropy_budget": 10, "capability_mask": 0b111}
+    action = {"req_level": 3, "entropy_cost": 12, "req_mask": 0b001}
+
+    is_valid, message = verifier.verify_action(state, action)
+
+    assert is_valid is False
+    assert "Semantic Boundary Leak" in message
+    assert "entropy_budget=-2" in message
+
+
+def test_clearance_boundary_is_rejected():
+    verifier = Layer1PolicyVerifier()
+    state = Layer1State(clearance=3, max_data_class=1, entropy_budget=10, capability_mask=0b111)
+    action = Layer1Action(req_level=4, entropy_cost=1, req_mask=0b001)
+
+    is_valid, message = verifier.verify_action(state, action)
+
+    assert is_valid is False
+    assert "max_data_class=4" in message
+
+
+def test_missing_capability_is_rejected_at_precondition():
+    verifier = Layer1PolicyVerifier()
+    state = Layer1State(clearance=3, max_data_class=1, entropy_budget=10, capability_mask=0b001)
+    action = Layer1Action(req_level=2, entropy_cost=1, req_mask=0b100)
+
+    is_valid, message = verifier.verify_action(state, action)
+
+    assert is_valid is False
+    assert "preconditions" in message


### PR DESCRIPTION
### Motivation
- Provide a stateful Layer 1 enforcement primitive that prevents semantic policy laundering by proving each state transition preserves global safety invariants instead of checking actions in isolation.
- Model TAS session state and candidate actions as SMT constraints so Z3 can detect multi-step boundary leaks (e.g., entropy exhaustion or capability escalation) before execution.

### Description
- Add `tas_pythonetics/src/tas_pythonetics/layer1_policy.py` implementing `Layer1State`, `Layer1Action`, and `Layer1PolicyVerifier` that encodes the invariant `Phi` and the state transition relation using Z3 and BitVec masks for capabilities.
- Perform a precondition SMT check on the materialized current state and requested capability, project the successor state (`S_{t+1}`), and return either success or a counterexample string when Z3 finds a violating model.
- Export `Layer1Action`, `Layer1PolicyVerifier`, and `Layer1State` from the package root (`tas_pythonetics/src/tas_pythonetics/__init__.py`).
- Declare `z3-solver>=4.12` in `tas_pythonetics/pyproject.toml` as a package dependency.
- Add unit tests `tas_pythonetics/tests/test_layer1_policy.py` that cover a valid transition, entropy exhaustion rejection, clearance boundary violation, and missing-capability precondition rejection.

### Testing
- Installed the package in editable mode with `python -m pip install -e tas_pythonetics` and ran the test suite with `pytest -q` (all tests passed). 
- Verified package metadata change in `tas_pythonetics/pyproject.toml` and public API exports in `tas_pythonetics/src/tas_pythonetics/__init__.py` via `git diff` checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5ffa4ef2fc833390edfc5a969a3db8)