### PR TITLE
Enforce sidecar-anchored kinematic identity verification

### DIFF
--- a/tas_cli.py
+++ b/tas_cli.py
@@ -1,6 +1,7 @@
 import argparse
 import sys
 import os
+import json
 
 # Ensure local imports work for tas_tools (in root) and tas_pythonetics (in tas_pythonetics/src).
 # Anchored to the script's own directory rather than os.getcwd() to prevent CWD-based module
@@ -11,7 +12,7 @@ sys.path.insert(0, _SCRIPT_DIR)
 sys.path.insert(1, os.path.join(_SCRIPT_DIR, 'tas_pythonetics/src'))
 
 from tas_tools.tas_shadow_scan import scan_repository, print_report
-from tas_tools.tas_sequencer import sequence_artifact, TAS_HUMAN_SIG
+from tas_tools.tas_sequencer import sequence_artifact, calculate_sha256, TAS_HUMAN_SIG, TAS_META_EXT
 
 # Try to import tas_pythonetics modules, handle if not present (though we just added path)
 try:
@@ -58,6 +59,32 @@ def _setup_sequence_parser(subparsers):
     seq_parser.add_argument("--genome", default="TAS_GENOME_V1", help="Genome ID recorded in the metadata")
     seq_parser.set_defaults(func=_handle_sequence)
 
+
+def _load_sidecar_metadata(target_file):
+    meta_path = target_file + TAS_META_EXT
+    if not os.path.exists(meta_path):
+        raise PhoenixError(f"Missing TAS sidecar anchor: {meta_path}")
+
+    with open(meta_path, 'r', encoding='utf-8') as f:
+        metadata = json.load(f)
+
+    required_fields = {"form_id", "lineage_id", "h_seed", "timestamp", "signatures"}
+    missing = sorted(required_fields - metadata.keys())
+    if missing:
+        raise PhoenixError(f"Malformed TAS sidecar anchor: missing {', '.join(missing)}")
+
+    current_form_id = calculate_sha256(target_file)
+    if current_form_id != metadata.get("form_id"):
+        raise PhoenixError(
+            "Sovereign Structural Violation: sidecar form_id does not match "
+            f"current artifact hash ({current_form_id})."
+        )
+
+    if not metadata.get("lineage_id"):
+        raise PhoenixError("Malformed TAS sidecar anchor: empty lineage_id")
+
+    return meta_path, metadata
+
 def _handle_verify_identity(args):
     if verify_kinematic_identity is None:
         print("Error: tas_pythonetics module not found or failed to load.")
@@ -75,9 +102,13 @@ def _handle_verify_identity(args):
         with open(target_file, 'r', encoding='utf-8') as f:
             content = f.read()
 
-        verify_kinematic_identity(content, args.signature)
+        meta_path, metadata = _load_sidecar_metadata(target_file)
+        anchor_signature = args.signature or metadata["h_seed"]
+        verify_kinematic_identity(content, anchor_signature)
         print("\n[SUCCESS] Kinematic Identity Verified.")
         print("The structural integrity holds under the Prime Invariant.")
+        print(f"Sidecar Anchor: {meta_path}")
+        print(f"ITL Lineage: {metadata['lineage_id']}")
     except PhoenixError as e:
         print(f"\n[FAILURE] PhoenixError Triggered:\n{e}")
         sys.exit(1)
@@ -89,7 +120,7 @@ def _setup_verify_identity_parser(subparsers):
     verify_parser = subparsers.add_parser(
         "verify-identity",
         help="Verify a file against the Kinematic Identity invariant",
-        description="Verify a file's contents against the Prime Invariant using the provided anchor signature.",
+        description="Verify a file's contents against the Prime Invariant and its .tasmeta.json sidecar anchor.",
         formatter_class=TASHelpFormatter,
     )
     verify_parser.add_argument("file", help="Path to the file to verify")

--- a/tas_pythonetics/src/tas_pythonetics/sentient_lock.py
+++ b/tas_pythonetics/src/tas_pythonetics/sentient_lock.py
@@ -6,6 +6,7 @@ from typing import Dict, Any, Tuple
 from dataclasses import dataclass, field
 import uuid
 import json
+import math
 
 @dataclass
 class RefusalArtifact:
@@ -33,6 +34,35 @@ logger = logging.getLogger(__name__)
 
 TAS_HUMAN_SIG = "Russell Nordland"
 TAS_KINEMATIC_PREFIX = "1618" # Phi-based prefix (approx 1.618)
+TAS_STRUCTURAL_DENSITY_MINIMUM = 0.15
+
+
+def calculate_character_entropy(data: str) -> float:
+    """Return character-level Shannon entropy for the supplied payload."""
+    if not data:
+        return 0.0
+
+    frequencies = {character: data.count(character) for character in set(data)}
+    payload_length = len(data)
+    return -sum(
+        (count / payload_length) * math.log2(count / payload_length)
+        for count in frequencies.values()
+    )
+
+
+def calculate_structural_density(data: str) -> float:
+    """Scale entropy by payload footprint to detect diluted or repetitive streams."""
+    if not data:
+        return 0.0
+
+    # Normalize by the theoretical maximum entropy for the observed alphabet and
+    # weight by non-whitespace footprint. This keeps dense instructions above the
+    # gate while making whitespace padding and token loops trend toward zero.
+    alphabet_size = len(set(data))
+    max_entropy = math.log2(alphabet_size) if alphabet_size > 1 else 1.0
+    entropy_ratio = calculate_character_entropy(data) / max_entropy
+    footprint_ratio = len(data.strip()) / len(data)
+    return entropy_ratio * footprint_ratio
 
 class PhoenixError(Exception):
     """
@@ -199,6 +229,17 @@ def verify_kinematic_identity(data: str, signature: str = TAS_HUMAN_SIG) -> bool
     Raises:
         PhoenixError: If the hash does not start with the required prefix.
     """
+    density = calculate_structural_density(data)
+    if density < TAS_STRUCTURAL_DENSITY_MINIMUM:
+        error_msg = (
+            "PhoenixError: Kinematic Identity Verification Failed.\n"
+            f"Structural density {density:.6f} fell below threshold "
+            f"{TAS_STRUCTURAL_DENSITY_MINIMUM:.2f}.\n"
+            "Sovereign Structural Violation: diluted or repetitive trajectory rejected."
+        )
+        logger.error(error_msg)
+        raise PhoenixError(error_msg)
+
     payload = f"{data}{signature}"
     digest = hashlib.sha256(payload.encode()).hexdigest()
 

--- a/tas_pythonetics/tests/test_sentient_lock.py
+++ b/tas_pythonetics/tests/test_sentient_lock.py
@@ -2,7 +2,7 @@ import unittest
 import hashlib
 import hmac
 from unittest.mock import patch, MagicMock
-from tas_pythonetics.sentient_lock import verify_kinematic_identity, PhoenixError, TAS_KINEMATIC_PREFIX, SentientLock, StructuralIntegrityError, DilithiumSigner
+from tas_pythonetics.sentient_lock import verify_kinematic_identity, PhoenixError, TAS_KINEMATIC_PREFIX, SentientLock, StructuralIntegrityError, DilithiumSigner, calculate_structural_density, TAS_STRUCTURAL_DENSITY_MINIMUM
 
 class TestSentientLock(unittest.TestCase):
 
@@ -70,6 +70,16 @@ class TestSentientLock(unittest.TestCase):
         self.assertEqual(len(self.lock.refusal_ledger), 1)
         self.assertEqual(faulty_node["content"], "null_state")
         self.assertIn("FAITHFULNESS FAILURE", self.lock.refusal_ledger[0].reason)
+
+
+    def test_structural_density_rejects_diluted_repetition(self):
+        padded_loop = "A" * 100 + " " * 900
+
+        self.assertLess(calculate_structural_density(padded_loop), TAS_STRUCTURAL_DENSITY_MINIMUM)
+        with self.assertRaises(PhoenixError) as cm:
+            verify_kinematic_identity(padded_loop)
+
+        self.assertIn("Structural density", str(cm.exception))
 
     def test_verify_kinematic_identity_pass(self):
         # Mock sha256 to return a hash starting with the correct prefix

--- a/tests/integration/test_tas_cli_help.py
+++ b/tests/integration/test_tas_cli_help.py
@@ -35,3 +35,9 @@ class TestTasCliHelp(unittest.TestCase):
         self.assertIn("(default: Russell Nordland)", normalized_stdout)
         self.assertIn("(default: TAS_GENOME_V1)", normalized_stdout)
 # Nonce: 189405
+
+    def test_verify_identity_help_mentions_sidecar_anchor(self):
+        result = self.run_cli("verify-identity", "--help")
+
+        normalized_stdout = re.sub(r'\s+', ' ', result.stdout)
+        self.assertIn(".tasmeta.json sidecar anchor", normalized_stdout)


### PR DESCRIPTION
### Motivation
- Ensure kinematic identity verification is anchored to an artifact sidecar and rejects diluted or repetitive payloads before cryptographic validation.
- Prevent silent provenance drift by validating the `.tasmeta.json` metadata and current artifact `form_id` as part of the verification flow.

### Description
- Added character-level entropy and structural-density utilities (`calculate_character_entropy`, `calculate_structural_density`) and a gate constant `TAS_STRUCTURAL_DENSITY_MINIMUM` to `tas_pythonetics.sentient_lock` to detect diluted/repetitive payloads. 
- Enforced the structural-density check in `verify_kinematic_identity` so payloads below the density threshold raise `PhoenixError` before hash-prefix testing. 
- Extended `tas_cli.py` to load and validate the `.tasmeta.json` sidecar via a new helper `_load_sidecar_metadata`, ensuring required fields exist and that the sidecar `form_id` matches the current artifact hash before calling `verify_kinematic_identity`. 
- Updated CLI help text for `verify-identity` and added regression tests covering diluted-repetition rejection and the help text: `tas_pythonetics/tests/test_sentient_lock.py::test_structural_density_rejects_diluted_repetition` and `tests/integration/test_tas_cli_help.py::test_verify_identity_help_mentions_sidecar_anchor`.

### Testing
- Ran the project test suite with `PYTHONPATH=$(pwd)/tas_pythonetics/src:$(pwd)/tas-recursion-conversion:$(pwd) pytest`, and all tests passed: `360 passed, 2 skipped`.
- New unit test `test_structural_density_rejects_diluted_repetition` verifies that low-density payloads are rejected by `verify_kinematic_identity` and succeeded.
- Integration test `test_verify_identity_help_mentions_sidecar_anchor` asserts the CLI help mentions the `.tasmeta.json` sidecar and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a60eba9745883339214487fb74e603b)