### PR TITLE
Promote PR #289 hardening changes to main

### DIFF
--- a/admission_gate.py
+++ b/admission_gate.py
@@ -12,6 +12,7 @@ import hashlib
 import os
 import re
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Mapping, Protocol
 
@@ -80,6 +81,19 @@ def authority_binding_hash(snapshot: AuthoritySnapshot) -> str:
         "valid_until": snapshot.valid_until,
     }
     return domain_hash(AUTHORITY_BINDING_DOMAIN, body)
+
+
+def _parse_timestamp(value: Any) -> datetime:
+    if not isinstance(value, str) or not value:
+        raise ValueError("timestamp must be a non-empty string")
+    normalized = f"{value[:-1]}+00:00" if value.endswith("Z") else value
+    try:
+        moment = datetime.fromisoformat(normalized)
+    except ValueError as error:
+        raise ValueError("invalid timestamp") from error
+    if moment.tzinfo is None:
+        raise ValueError("timestamp must include a timezone offset")
+    return moment.astimezone(timezone.utc)
 
 
 class AuthorityResolver(Protocol):
@@ -518,16 +532,19 @@ class AdmissionGatekeeper:
     ) -> bool:
         if snapshot is None:
             return False
-        return (
-            snapshot.context_snapshot_hash == context.context_snapshot_hash
-            and snapshot.context_snapshot_hash
-            == envelope["context_snapshot_hash"]
-            and snapshot.checkpoint_hash
-            == envelope["authority_checkpoint_hash"]
-            and snapshot.authority_epoch == context.effective_epoch
-            and context.authority_binding_hash
-            == authority_binding_hash(snapshot)
-        )
+        try:
+            return (
+                snapshot.context_snapshot_hash == context.context_snapshot_hash
+                and snapshot.context_snapshot_hash
+                == envelope["context_snapshot_hash"]
+                and snapshot.checkpoint_hash
+                == envelope["authority_checkpoint_hash"]
+                and snapshot.authority_epoch == context.effective_epoch
+                and context.authority_binding_hash
+                == authority_binding_hash(snapshot)
+            )
+        except (AttributeError, KeyError, TypeError, ValueError):
+            return False
 
     def _context_lineage_valid(
         self, envelope: Mapping[str, Any], context: ContextSnapshot
@@ -558,8 +575,12 @@ class AdmissionGatekeeper:
             return False
         if (
             envelope["signature_algorithm"] != snapshot.algorithm
-            or current_time > snapshot.valid_until
         ):
+            return False
+        try:
+            if _parse_timestamp(current_time) > _parse_timestamp(snapshot.valid_until):
+                return False
+        except ValueError:
             return False
         try:
             signature = base64.b64decode(envelope["signature"], validate=True)
@@ -681,3 +702,6 @@ class AdmissionGatekeeper:
                 "failure_code": "RECEIPT_PRESERVATION_UNAVAILABLE",
                 "durable_receipt": False,
             }
+
+
+AdmissionGate = AdmissionGatekeeper

--- a/tests/test_admission_gate.py
+++ b/tests/test_admission_gate.py
@@ -1,7 +1,8 @@
 import base64
 import os
 import sys
-from dataclasses import replace
+from dataclasses import dataclass, replace
+from unittest.mock import MagicMock
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
@@ -10,6 +11,7 @@ from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 
 from admission_gate import (
     AUTHORIZATION_DOMAIN,
+    AdmissionGate,
     AdmissionGatekeeper,
     AuthoritySnapshot,
     AuthenticatedLineageVerifier,
@@ -45,6 +47,17 @@ class Resolver:
             == (self.snapshot.credential_id, self.snapshot.checkpoint_hash)
             else None
         )
+
+
+@dataclass
+class PartialAuthoritySnapshot:
+    authority_epoch: int
+    checkpoint_hash: str
+    context_snapshot_hash: str
+    algorithm: str
+    public_key: str
+    valid_until: str
+    revoked: bool = False
 
 
 def _gate():
@@ -169,6 +182,34 @@ def test_public_key_cannot_forge_authorization_signature():
     assert result["durable_receipt"]
 
 
+def test_expired_offset_timestamp_is_refused():
+    gate, authority, _, context, _ = _gate()
+    candidate, envelope = _request(authority, context)
+    result = gate.evaluate(
+        raw_candidate=candidate,
+        raw_envelope=envelope,
+        current_time="2030-01-01T00:00:00-01:00",
+    )
+    assert result["resulting_state"] == "REFUSED"
+    assert result["receipt"]["failure_code"] == "AUTHORIZATION_REFUSED"
+
+
+def test_fractional_second_past_expiry_is_refused():
+    gate, authority, _, context, _ = _gate()
+    candidate, envelope = _request(authority, context)
+    result = gate.evaluate(
+        raw_candidate=candidate,
+        raw_envelope=envelope,
+        current_time="2030-01-01T00:00:00.001Z",
+    )
+    assert result["resulting_state"] == "REFUSED"
+    assert result["receipt"]["failure_code"] == "AUTHORIZATION_REFUSED"
+
+
+def test_admission_gate_alias_maps_to_gatekeeper():
+    assert AdmissionGate is AdmissionGatekeeper
+
+
 def test_context_is_verified_before_candidate_is_parsed():
     gate, authority, _, context, _ = _gate()
     _, envelope = _request(authority, context)
@@ -200,6 +241,62 @@ def test_authority_snapshot_cannot_swap_context_mid_flight():
         result["receipt"]["failure_code"]
         == "CONTEXT_AUTHORITY_MISMATCH"
     )
+
+
+def test_partial_snapshot_fails_context_authority_validation_closed():
+    gate = AdmissionGate.__new__(AdmissionGate)
+    context = ContextSnapshot.build(
+        namespace_id="tas:core",
+        context_sequence=0,
+        definition_ids=["a" * 64],
+        invariant_set_id="b" * 64,
+        authority_binding_hash="c" * 64,
+        parent_context_hash=None,
+        effective_epoch=1,
+    )
+    snapshot = PartialAuthoritySnapshot(
+        authority_epoch=1,
+        checkpoint_hash="d" * 64,
+        context_snapshot_hash=context.context_snapshot_hash,
+        algorithm="Ed25519",
+        public_key="pubkey-1",
+        valid_until="2030-01-01T00:00:00Z",
+    )
+    envelope = {
+        "context_snapshot_hash": context.context_snapshot_hash,
+        "authority_checkpoint_hash": "d" * 64,
+    }
+
+    assert not gate._context_authority_valid(envelope, context, snapshot)
+
+
+def test_record_lineage_unavailable_returns_cutoff_with_missing_parent():
+    gate = AdmissionGate.__new__(AdmissionGate)
+    gate.gatekeeper_id = "gk-01"
+    gate.ledger = MagicMock()
+    gate.ledger.get_receipt.return_value = None
+    gate.receipt_signer = MagicMock()
+
+    result = gate._record(
+        envelope={
+            "parent_receipt_hash": "0" * 64,
+            "candidate_hash": "1" * 64,
+            "nonce": "nonce-123",
+        },
+        snapshot=None,
+        context=None,
+        candidate={"data": "test"},
+        raw_candidate_hash="2" * 64,
+        current_time="2026-08-03T13:10:00Z",
+        admitted=False,
+        failure="INVALID_LINEAGE",
+    )
+
+    assert result == {
+        "resulting_state": "CUTOFF",
+        "failure_code": "LINEAGE_UNAVAILABLE",
+        "durable_receipt": False,
+    }
 
 
 def test_context_lineage_cannot_teleport_across_unrelated_contexts():


### PR DESCRIPTION
PR #289 was merged into the already-consumed `codex/integrate-pull-request-48-changes` branch rather than `main`.

This PR promotes only the resolved two-file result onto the current `main` lineage:

- timezone-aware UTC expiry validation
- fail-closed malformed authority snapshot handling
- `AdmissionGate` compatibility alias
- regression coverage for timestamp offsets, fractional seconds, malformed snapshots, unavailable lineage parents, and API compatibility

Security preservation: the externally supplied trusted gatekeeper key requirement from PR #288 remains intact. No stale head snapshot or unrelated branch history is included.