### PR TITLE
Harden Pythonetics with coinductive governed runtime

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -19,10 +19,12 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
+          python-version: "3.11"
 
       - name: Install dependencies
-        run: pip install pytest
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pytest -r requirements.txt
 
       - name: Run organic mechanics tests
         run: PYTHONPATH=$(pwd)/tas_pythonetics/src:$(pwd)/tas-recursion-conversion:$(pwd) pytest tas_pythonetics/tests/ -q

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -9,12 +9,28 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
+          python-version: "3.11"
+
       - name: Install dependencies
-        run: python -m pip install pytest -r requirements.txt
-      - name: Run tests
-        run: PYTHONPATH=$(pwd)/tas_pythonetics/src:$(pwd)/tas-recursion-conversion:$(pwd) pytest -q
-# Nonce: 56328
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt
+          python -m pip install -e "./tas_pythonetics[test]"
+
+      - name: Run repository test suite
+        run: |
+          PYTHONPATH=$(pwd)/tas_pythonetics/src:$(pwd)/tas-recursion-conversion:$(pwd) pytest -q
+
+      - name: Prove Pythonetics runtime conformance
+        run: |
+          pytest tas_pythonetics/tests/test_runtime.py -v \
+            --cov=tas_pythonetics.core \
+            --cov=tas_pythonetics.authority \
+            --cov=tas_pythonetics.capabilities \
+            --cov=tas_pythonetics.runtime \
+            --cov-report=term-missing \
+            --cov-fail-under=100

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 cryptography>=42.0.0
+rfc8785>=0.1.4

--- a/tas_pythonetics/README.md
+++ b/tas_pythonetics/README.md
@@ -1,3 +1,56 @@
 # tas_pythonetics
 
-Initial scaffolding for the tas_pythonetics package.
+Pythonetics provides executable grammar for recursive sovereignty within TAS.
+
+## Hardened governed runtime
+
+The governed runtime treats admissibility as a continuously preserved invariant. Every terminal decision is a signed, hash-linked receipt with one of three truthful outcomes:
+
+- `COMMITTED`: the protected effect completed and the state head advanced.
+- `REFUSED`: no protected effect occurred; the state head is unchanged.
+- `EXECUTION_UNCERTAIN`: commit outcome cannot be proven; the runtime halts pending external reconciliation.
+
+The runtime enforces:
+
+- Ed25519 verification over an RFC 8785 canonical preimage with domain separation;
+- externally lodged authority records, effective-time checks, and exact scope grants;
+- parent-state lineage continuity and one-shot nonce reservation;
+- capability resolution through internal per-transition effector factories;
+- two-phase preparation with explicit `CommitRejected` semantics;
+- separate state and audit heads so refusals remain evidentiary without mutating protected state;
+- Ed25519-signed receipts for committed, refused, and uncertain decisions.
+
+## Layout
+
+```text
+src/tas_pythonetics/
+├── authority.py       # External authority registry
+├── capabilities.py    # Capability registry and effector contracts
+├── core.py            # Immutable payload, authority, state, and receipt types
+└── runtime.py         # Governed transition engine and receipt verifier
+
+tests/test_runtime.py  # Coinductive runtime conformance suite
+```
+
+## Verification
+
+```bash
+python -m pip install -e "./tas_pythonetics[test]"
+pytest tas_pythonetics/tests/test_runtime.py -v \
+  --cov=tas_pythonetics.core \
+  --cov=tas_pythonetics.authority \
+  --cov=tas_pythonetics.capabilities \
+  --cov=tas_pythonetics.runtime \
+  --cov-report=term-missing \
+  --cov-fail-under=100
+```
+
+The load-bearing rule is enforced operationally:
+
+```text
+REFUSED => protected state delta is zero
+```
+
+An unexpected commit exception is never mislabeled as refusal.
+
+The included state and nonce stores are process-local reference components. A deployment requiring crash persistence or multi-node admission must place those values behind a durable, atomic store before claiming production durability.

--- a/tas_pythonetics/pyproject.toml
+++ b/tas_pythonetics/pyproject.toml
@@ -1,7 +1,21 @@
 [build-system]
-requires = ["setuptools", "wheel"]
+requires = ["setuptools>=61.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "tas_pythonetics"
 version = "0.1.0"
+requires-python = ">=3.9"
+dependencies = [
+    "cryptography>=42.0.0",
+    "rfc8785>=0.1.4",
+]
+
+[project.optional-dependencies]
+test = [
+    "pytest>=7.4.0",
+    "pytest-cov>=4.1.0",
+]
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/tas_pythonetics/src/tas_pythonetics/__init__.py
+++ b/tas_pythonetics/src/tas_pythonetics/__init__.py
@@ -1,21 +1,46 @@
-"""
-tas_pythonetics
-Executable grammar for recursive sovereignty within the TAS framework.
-"""
+"""Public interface for the TAS Pythonetics package."""
+
+from .authority import AuthorityRegistry
+from .capabilities import (
+    CapabilityRegistry,
+    CommitRejected,
+    PreparationRejected,
+    TwoPhaseEffector,
+)
+from .core import (
+    GENESIS_HASH,
+    PROTOCOL_VERSION,
+    AuthorityRecord,
+    CryptographicReceipt,
+    ExecutionPayload,
+    PipelineState,
+)
+from .runtime import HardenedPythoneticsRuntime
 from .tas_pythonetics import (
-    recursive_truth_amplify,
     TAS_recursive_authenticate,
     detect_drift,
     initiate_self_heal,
+    recursive_truth_amplify,
 )
+
 __all__ = [
-    "recursive_truth_amplify",
+    "AuthorityRecord",
+    "AuthorityRegistry",
+    "CapabilityRegistry",
+    "CommitRejected",
+    "CryptographicReceipt",
+    "ExecutionPayload",
+    "GENESIS_HASH",
+    "HardenedPythoneticsRuntime",
+    "PipelineState",
+    "PreparationRejected",
+    "PROTOCOL_VERSION",
     "TAS_recursive_authenticate",
+    "TwoPhaseEffector",
     "detect_drift",
     "initiate_self_heal",
+    "recursive_truth_amplify",
 ]
 
-# Immutable TAS_DNA as the logarithmic substrate for agnostic cursive coherence
+# Immutable TAS_DNA as the logarithmic substrate for agnostic cursive coherence.
 TAS_DNA = "TrueAlpha-singularity:LogarithmicSubstrate_v1.0"
-# Core artifact; hash for immutability
-# Nonce: 138801

--- a/tas_pythonetics/src/tas_pythonetics/authority.py
+++ b/tas_pythonetics/src/tas_pythonetics/authority.py
@@ -1,0 +1,48 @@
+"""External authority registry for Pythonetics transitions."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from threading import RLock
+from typing import Dict, Optional
+
+from .core import AuthorityRecord
+
+
+class AuthorityRegistry:
+    """Stores externally lodged authority records; it never executes actions."""
+
+    def __init__(self) -> None:
+        self._records: Dict[str, AuthorityRecord] = {}
+        self._lock = RLock()
+
+    def register(self, record: AuthorityRecord, *, replace_existing: bool = False) -> None:
+        if not record.authority_id:
+            raise ValueError("authority_id must be non-empty")
+        if not record.scopes:
+            raise ValueError("authority record must grant at least one scope")
+        if record.valid_until < record.valid_from:
+            raise ValueError("authority validity window is inverted")
+        try:
+            key_bytes = bytes.fromhex(record.public_key_hex)
+        except ValueError as exc:
+            raise ValueError("authority public key must be hexadecimal") from exc
+        if len(key_bytes) != 32:
+            raise ValueError("Ed25519 public key must be 32 bytes")
+
+        normalized = replace(record, public_key_hex=record.public_key_hex.lower())
+        with self._lock:
+            if record.authority_id in self._records and not replace_existing:
+                raise ValueError(f"authority already registered: {record.authority_id}")
+            self._records[record.authority_id] = normalized
+
+    def resolve(self, authority_id: str) -> Optional[AuthorityRecord]:
+        with self._lock:
+            return self._records.get(authority_id)
+
+    def revoke(self, authority_id: str, revoked_at: int) -> None:
+        with self._lock:
+            record = self._records.get(authority_id)
+            if record is None:
+                raise KeyError(authority_id)
+            self._records[authority_id] = replace(record, revoked_at=revoked_at)

--- a/tas_pythonetics/src/tas_pythonetics/capabilities.py
+++ b/tas_pythonetics/src/tas_pythonetics/capabilities.py
@@ -1,0 +1,77 @@
+"""Capability registry and transactional effector contracts."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from threading import RLock
+from typing import Any, Callable, Dict, Mapping, Optional
+
+
+class PreparationRejected(RuntimeError):
+    """Preparation was rejected before any protected effect occurred."""
+
+
+class CommitRejected(RuntimeError):
+    """Commit was rejected and the effector guarantees no protected effect occurred."""
+
+
+class TwoPhaseEffector(ABC):
+    """
+    Per-transition capability instance.
+
+    ``prepare`` may stage reversible local state but must not create a protected
+    external effect. ``CommitRejected`` is the only commit failure that permits
+    the runtime to emit REFUSED. Any other commit exception is treated as an
+    uncertain outcome and halts further execution pending reconciliation.
+    """
+
+    @abstractmethod
+    def prepare(self, parameters: Mapping[str, Any]) -> bool:
+        """Stage and validate the effect without changing protected state."""
+
+    @abstractmethod
+    def commit(self) -> Mapping[str, Any]:
+        """Atomically commit the staged effect and return a canonicalizable result."""
+
+    @abstractmethod
+    def rollback(self) -> None:
+        """Clear uncommitted staged state."""
+
+
+@dataclass(frozen=True)
+class CapabilityBinding:
+    action_id: str
+    required_scope: str
+    factory: Callable[[], TwoPhaseEffector]
+
+
+class CapabilityRegistry:
+    """Resolves admitted action identifiers to internal capability factories."""
+
+    def __init__(self) -> None:
+        self._registry: Dict[str, CapabilityBinding] = {}
+        self._lock = RLock()
+
+    def register(
+        self,
+        action_id: str,
+        required_scope: str,
+        factory: Callable[[], TwoPhaseEffector],
+        *,
+        replace_existing: bool = False,
+    ) -> None:
+        if not action_id or not required_scope:
+            raise ValueError("action_id and required_scope must be non-empty")
+        if not callable(factory):
+            raise TypeError("factory must be callable")
+
+        binding = CapabilityBinding(action_id, required_scope, factory)
+        with self._lock:
+            if action_id in self._registry and not replace_existing:
+                raise ValueError(f"capability already registered: {action_id}")
+            self._registry[action_id] = binding
+
+    def resolve(self, action_id: str) -> Optional[CapabilityBinding]:
+        with self._lock:
+            return self._registry.get(action_id)

--- a/tas_pythonetics/src/tas_pythonetics/core.py
+++ b/tas_pythonetics/src/tas_pythonetics/core.py
@@ -1,0 +1,84 @@
+"""Core immutable types for the Pythonetics governed runtime."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum, auto
+from typing import Any, Mapping, Optional
+
+
+PROTOCOL_VERSION = "tas.pythonetics.transition.v1"
+GENESIS_HASH = "0" * 64
+
+
+class PipelineState(Enum):
+    S0_UNTRUSTED_INGRESS = auto()
+    S1_AUTHENTICATED_AUTHORITY = auto()
+    S2_CONTEXT_BOUND = auto()
+    S3_POSITIVE_AUTHORIZATION = auto()
+    S4_REPLAY_RESERVED = auto()
+    S5_CAPABILITY_ADMITTED = auto()
+    S6_PREPARED = auto()
+    S7_COMMITTED_AND_SEALED = auto()
+    SR_REFUSED = auto()
+    SU_EXECUTION_UNCERTAIN = auto()
+
+
+@dataclass(frozen=True)
+class ExecutionPayload:
+    """Signed candidate transition presented to the runtime."""
+
+    protocol_version: str
+    action_id: str
+    authority_id: str
+    public_key_hex: str
+    signature_hex: str
+    context_scope: str
+    parameters: Mapping[str, Any]
+    issued_at: int
+    expires_at: int
+    nonce: str
+    parent_state_hash: str
+
+
+@dataclass(frozen=True)
+class AuthorityRecord:
+    """Externally lodged authority and its effective scope."""
+
+    authority_id: str
+    public_key_hex: str
+    scopes: frozenset[str]
+    valid_from: int
+    valid_until: int
+    revoked_at: Optional[int] = None
+
+    def effective_at(self, timestamp: int) -> bool:
+        if not (self.valid_from <= timestamp <= self.valid_until):
+            return False
+        return self.revoked_at is None or timestamp < self.revoked_at
+
+
+@dataclass(frozen=True)
+class CryptographicReceipt:
+    """Signed decision evidence emitted for every terminal runtime decision."""
+
+    receipt_id: str
+    protocol_version: str
+    action_id: str
+    authority_id: str
+    context_scope: str
+    nonce: str
+    status: str
+    state: str
+    failed_at_state: Optional[str]
+    reason_code: Optional[str]
+    candidate_hash: str
+    payload_digest: str
+    result_digest: str
+    parent_state_hash: str
+    state_hash: str
+    parent_audit_hash: str
+    audit_hash: str
+    decision_time: int
+    receipt_public_key_hex: str
+    receipt_signature_hex: str

--- a/tas_pythonetics/src/tas_pythonetics/runtime.py
+++ b/tas_pythonetics/src/tas_pythonetics/runtime.py
@@ -1,0 +1,590 @@
+"""Hardened Pythonetics admission, execution, and receipt runtime."""
+
+from __future__ import annotations
+
+import hashlib
+import time
+from threading import RLock
+from typing import Any, Callable, Mapping, Optional
+
+import rfc8785
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ed25519
+
+from .authority import AuthorityRegistry
+from .capabilities import (
+    CapabilityRegistry,
+    CommitRejected,
+    PreparationRejected,
+    TwoPhaseEffector,
+)
+from .core import (
+    GENESIS_HASH,
+    PROTOCOL_VERSION,
+    CryptographicReceipt,
+    ExecutionPayload,
+    PipelineState,
+)
+
+_SIGNATURE_DOMAIN = b"TAS\x00PYTHONETICS\x00TRANSITION\x00v1\x00"
+_STATE_DOMAIN = b"TAS\x00PYTHONETICS\x00STATE\x00v1\x00"
+_AUDIT_DOMAIN = b"TAS\x00PYTHONETICS\x00AUDIT\x00v1\x00"
+_PAYLOAD_DOMAIN = b"TAS\x00PYTHONETICS\x00PAYLOAD\x00v1\x00"
+
+
+class HardenedPythoneticsRuntime:
+    """
+    Serialized, fail-closed transition runtime.
+
+    A REFUSED decision is emitted only before commit or after an explicit
+    ``CommitRejected`` guarantee. Unexpected commit failures are recorded as
+    EXECUTION_UNCERTAIN and permanently halt this runtime instance until an
+    external reconciliation process replaces or repairs it.
+    """
+
+    def __init__(
+        self,
+        capability_registry: CapabilityRegistry,
+        authority_registry: AuthorityRegistry,
+        receipt_signing_key: ed25519.Ed25519PrivateKey,
+        *,
+        genesis_hash: str = GENESIS_HASH,
+        max_candidate_lifetime: int = 300,
+        clock: Optional[Callable[[], int]] = None,
+    ) -> None:
+        self._validate_hash(genesis_hash, "genesis_hash")
+        if max_candidate_lifetime <= 0:
+            raise ValueError("max_candidate_lifetime must be positive")
+
+        self.capability_registry = capability_registry
+        self.authority_registry = authority_registry
+        self._receipt_signing_key = receipt_signing_key
+        self._receipt_public_key_hex = receipt_signing_key.public_key().public_bytes(
+            encoding=serialization.Encoding.Raw,
+            format=serialization.PublicFormat.Raw,
+        ).hex()
+        self._clock = clock or (lambda: int(time.time()))
+        self._max_candidate_lifetime = max_candidate_lifetime
+        self._seen_nonces: set[str] = set()
+        self._state_head = genesis_hash.lower()
+        self._audit_head = genesis_hash.lower()
+        self._halted = False
+        self._lock = RLock()
+
+    @property
+    def latest_state_hash(self) -> str:
+        return self._state_head
+
+    @property
+    def latest_audit_hash(self) -> str:
+        return self._audit_head
+
+    @property
+    def halted(self) -> bool:
+        return self._halted
+
+    @staticmethod
+    def canonicalize(data: Any) -> bytes:
+        """Serialize data using RFC 8785 JSON Canonicalization Scheme."""
+        return rfc8785.dumps(data)
+
+    def compute_candidate_preimage(self, payload: ExecutionPayload) -> bytes:
+        unsigned = {
+            "protocol_version": payload.protocol_version,
+            "action_id": payload.action_id,
+            "authority_id": payload.authority_id,
+            "public_key_hex": payload.public_key_hex.lower(),
+            "context_scope": payload.context_scope,
+            "parameters": dict(payload.parameters),
+            "issued_at": payload.issued_at,
+            "expires_at": payload.expires_at,
+            "nonce": payload.nonce,
+            "parent_state_hash": payload.parent_state_hash.lower(),
+        }
+        return _SIGNATURE_DOMAIN + self.canonicalize(unsigned)
+
+    def compute_candidate_hash(self, payload: ExecutionPayload) -> str:
+        return hashlib.sha256(self.compute_candidate_preimage(payload)).hexdigest()
+
+    def process_transition(self, payload: ExecutionPayload) -> CryptographicReceipt:
+        with self._lock:
+            decision_time = self._clock()
+            try:
+                candidate_preimage = self.compute_candidate_preimage(payload)
+                candidate_hash = hashlib.sha256(candidate_preimage).hexdigest()
+                payload_digest = self._payload_digest(payload)
+            except (TypeError, ValueError, rfc8785.CanonicalizationError) as exc:
+                candidate_hash = self._malformed_candidate_fingerprint(payload, exc)
+                return self._refuse(
+                    payload,
+                    PipelineState.S0_UNTRUSTED_INGRESS,
+                    "ERR_CANDIDATE_NOT_CANONICALIZABLE",
+                    candidate_hash,
+                    candidate_hash,
+                    decision_time,
+                )
+
+            if self._halted:
+                return self._refuse(
+                    payload,
+                    PipelineState.S0_UNTRUSTED_INGRESS,
+                    "ERR_RUNTIME_HALTED_PENDING_RECONCILIATION",
+                    candidate_hash,
+                    payload_digest,
+                    decision_time,
+                )
+
+            if payload.protocol_version != PROTOCOL_VERSION:
+                return self._refuse(
+                    payload,
+                    PipelineState.S0_UNTRUSTED_INGRESS,
+                    "ERR_UNSUPPORTED_PROTOCOL_VERSION",
+                    candidate_hash,
+                    payload_digest,
+                    decision_time,
+                )
+
+            if not self._verify_ed25519_signature(payload, candidate_preimage):
+                return self._refuse(
+                    payload,
+                    PipelineState.S0_UNTRUSTED_INGRESS,
+                    "ERR_INVALID_CRYPTO_SIGNATURE",
+                    candidate_hash,
+                    payload_digest,
+                    decision_time,
+                )
+
+            context_error = self._context_error(payload, decision_time)
+            if context_error is not None:
+                return self._refuse(
+                    payload,
+                    PipelineState.S1_AUTHENTICATED_AUTHORITY,
+                    context_error,
+                    candidate_hash,
+                    payload_digest,
+                    decision_time,
+                )
+
+            authority_error = self._authority_error(payload, decision_time)
+            if authority_error is not None:
+                return self._refuse(
+                    payload,
+                    PipelineState.S2_CONTEXT_BOUND,
+                    authority_error,
+                    candidate_hash,
+                    payload_digest,
+                    decision_time,
+                )
+
+            if payload.nonce in self._seen_nonces:
+                return self._refuse(
+                    payload,
+                    PipelineState.S3_POSITIVE_AUTHORIZATION,
+                    "ERR_REPLAY_NONCE_DETECTED",
+                    candidate_hash,
+                    payload_digest,
+                    decision_time,
+                )
+            self._seen_nonces.add(payload.nonce)
+
+            binding = self.capability_registry.resolve(payload.action_id)
+            if binding is None:
+                return self._refuse(
+                    payload,
+                    PipelineState.S4_REPLAY_RESERVED,
+                    "ERR_UNREGISTERED_CAPABILITY",
+                    candidate_hash,
+                    payload_digest,
+                    decision_time,
+                )
+            if binding.required_scope != payload.context_scope:
+                return self._refuse(
+                    payload,
+                    PipelineState.S4_REPLAY_RESERVED,
+                    "ERR_CAPABILITY_SCOPE_MISMATCH",
+                    candidate_hash,
+                    payload_digest,
+                    decision_time,
+                )
+
+            try:
+                effector = binding.factory()
+            except Exception as exc:  # factory is internal, but failures are evidentiary
+                return self._refuse(
+                    payload,
+                    PipelineState.S5_CAPABILITY_ADMITTED,
+                    f"ERR_EFFECTOR_FACTORY:{type(exc).__name__}",
+                    candidate_hash,
+                    payload_digest,
+                    decision_time,
+                )
+            if not isinstance(effector, TwoPhaseEffector):
+                return self._refuse(
+                    payload,
+                    PipelineState.S5_CAPABILITY_ADMITTED,
+                    "ERR_EFFECTOR_CONTRACT_VIOLATION",
+                    candidate_hash,
+                    payload_digest,
+                    decision_time,
+                )
+
+            try:
+                prepared = effector.prepare(dict(payload.parameters))
+                if not prepared:
+                    raise PreparationRejected("prepare returned false")
+            except PreparationRejected:
+                if not self._rollback_cleanly(effector):
+                    return self._uncertain(
+                        payload,
+                        PipelineState.S5_CAPABILITY_ADMITTED,
+                        "ERR_ROLLBACK_FAILED_AFTER_PREPARATION_REJECTION",
+                        candidate_hash,
+                        payload_digest,
+                        decision_time,
+                    )
+                return self._refuse(
+                    payload,
+                    PipelineState.S5_CAPABILITY_ADMITTED,
+                    "ERR_EFFECTOR_PREPARATION_REJECTED",
+                    candidate_hash,
+                    payload_digest,
+                    decision_time,
+                )
+            except Exception as exc:
+                if not self._rollback_cleanly(effector):
+                    return self._uncertain(
+                        payload,
+                        PipelineState.S5_CAPABILITY_ADMITTED,
+                        f"ERR_PREPARE_AND_ROLLBACK_FAILED:{type(exc).__name__}",
+                        candidate_hash,
+                        payload_digest,
+                        decision_time,
+                    )
+                return self._refuse(
+                    payload,
+                    PipelineState.S5_CAPABILITY_ADMITTED,
+                    f"ERR_EFFECTOR_PREPARE_EXCEPTION:{type(exc).__name__}",
+                    candidate_hash,
+                    payload_digest,
+                    decision_time,
+                )
+
+            try:
+                result = effector.commit()
+            except CommitRejected:
+                if not self._rollback_cleanly(effector):
+                    return self._uncertain(
+                        payload,
+                        PipelineState.S6_PREPARED,
+                        "ERR_ROLLBACK_FAILED_AFTER_COMMIT_REJECTION",
+                        candidate_hash,
+                        payload_digest,
+                        decision_time,
+                    )
+                return self._refuse(
+                    payload,
+                    PipelineState.S6_PREPARED,
+                    "ERR_EFFECTOR_COMMIT_REJECTED",
+                    candidate_hash,
+                    payload_digest,
+                    decision_time,
+                )
+            except Exception as exc:
+                self._rollback_cleanly(effector)
+                return self._uncertain(
+                    payload,
+                    PipelineState.S6_PREPARED,
+                    f"ERR_COMMIT_OUTCOME_UNKNOWN:{type(exc).__name__}",
+                    candidate_hash,
+                    payload_digest,
+                    decision_time,
+                )
+
+            try:
+                result_digest = hashlib.sha256(self.canonicalize(dict(result))).hexdigest()
+            except (TypeError, ValueError, rfc8785.CanonicalizationError) as exc:
+                return self._uncertain(
+                    payload,
+                    PipelineState.S6_PREPARED,
+                    f"ERR_COMMITTED_RESULT_NOT_CANONICALIZABLE:{type(exc).__name__}",
+                    candidate_hash,
+                    payload_digest,
+                    decision_time,
+                )
+
+            return self._commit_receipt(
+                payload,
+                candidate_hash,
+                payload_digest,
+                result_digest,
+                decision_time,
+            )
+
+    def _verify_ed25519_signature(
+        self, payload: ExecutionPayload, candidate_preimage: bytes
+    ) -> bool:
+        try:
+            public_key_bytes = bytes.fromhex(payload.public_key_hex)
+            signature_bytes = bytes.fromhex(payload.signature_hex)
+            if len(public_key_bytes) != 32 or len(signature_bytes) != 64:
+                return False
+            public_key = ed25519.Ed25519PublicKey.from_public_bytes(public_key_bytes)
+            public_key.verify(signature_bytes, candidate_preimage)
+            return True
+        except (ValueError, InvalidSignature):
+            return False
+
+    def _context_error(self, payload: ExecutionPayload, now: int) -> Optional[str]:
+        if not payload.action_id or not payload.authority_id or not payload.nonce:
+            return "ERR_REQUIRED_FIELD_EMPTY"
+        if payload.expires_at < payload.issued_at:
+            return "ERR_INVERTED_VALIDITY_WINDOW"
+        if payload.expires_at - payload.issued_at > self._max_candidate_lifetime:
+            return "ERR_VALIDITY_WINDOW_TOO_LONG"
+        if not (payload.issued_at <= now <= payload.expires_at):
+            return "ERR_CANDIDATE_NOT_CURRENTLY_EFFECTIVE"
+        if payload.parent_state_hash.lower() != self._state_head:
+            return "ERR_PARENT_STATE_MISMATCH"
+        return None
+
+    def _authority_error(self, payload: ExecutionPayload, now: int) -> Optional[str]:
+        record = self.authority_registry.resolve(payload.authority_id)
+        if record is None:
+            return "ERR_UNKNOWN_EXTERNAL_AUTHORITY"
+        if record.public_key_hex != payload.public_key_hex.lower():
+            return "ERR_AUTHORITY_KEY_MISMATCH"
+        if not record.effective_at(now):
+            return "ERR_AUTHORITY_NOT_CURRENTLY_EFFECTIVE"
+        if payload.issued_at < record.valid_from or payload.expires_at > record.valid_until:
+            return "ERR_CANDIDATE_OUTSIDE_AUTHORITY_WINDOW"
+        if not payload.context_scope or payload.context_scope not in record.scopes:
+            return "ERR_SCOPE_NOT_GRANTED_BY_AUTHORITY"
+        return None
+
+    def _payload_digest(self, payload: ExecutionPayload) -> str:
+        signed_payload = {
+            "protocol_version": payload.protocol_version,
+            "action_id": payload.action_id,
+            "authority_id": payload.authority_id,
+            "public_key_hex": payload.public_key_hex.lower(),
+            "signature_hex": payload.signature_hex.lower(),
+            "context_scope": payload.context_scope,
+            "parameters": dict(payload.parameters),
+            "issued_at": payload.issued_at,
+            "expires_at": payload.expires_at,
+            "nonce": payload.nonce,
+            "parent_state_hash": payload.parent_state_hash.lower(),
+        }
+        return hashlib.sha256(_PAYLOAD_DOMAIN + self.canonicalize(signed_payload)).hexdigest()
+
+    def _commit_receipt(
+        self,
+        payload: ExecutionPayload,
+        candidate_hash: str,
+        payload_digest: str,
+        result_digest: str,
+        decision_time: int,
+    ) -> CryptographicReceipt:
+        parent_state_hash = self._state_head
+        state_body = {
+            "parent_state_hash": parent_state_hash,
+            "candidate_hash": candidate_hash,
+            "result_digest": result_digest,
+        }
+        new_state_hash = hashlib.sha256(
+            _STATE_DOMAIN + self.canonicalize(state_body)
+        ).hexdigest()
+        receipt = self._seal_receipt(
+            payload=payload,
+            status="COMMITTED",
+            state=PipelineState.S7_COMMITTED_AND_SEALED,
+            failed_at_state=None,
+            reason_code=None,
+            candidate_hash=candidate_hash,
+            payload_digest=payload_digest,
+            result_digest=result_digest,
+            state_hash=new_state_hash,
+            decision_time=decision_time,
+        )
+        self._state_head = new_state_hash
+        return receipt
+
+    def _refuse(
+        self,
+        payload: ExecutionPayload,
+        failed_at_state: PipelineState,
+        reason_code: str,
+        candidate_hash: str,
+        payload_digest: str,
+        decision_time: int,
+    ) -> CryptographicReceipt:
+        return self._seal_receipt(
+            payload=payload,
+            status="REFUSED",
+            state=PipelineState.SR_REFUSED,
+            failed_at_state=failed_at_state,
+            reason_code=reason_code,
+            candidate_hash=candidate_hash,
+            payload_digest=payload_digest,
+            result_digest=GENESIS_HASH,
+            state_hash=self._state_head,
+            decision_time=decision_time,
+        )
+
+    def _uncertain(
+        self,
+        payload: ExecutionPayload,
+        failed_at_state: PipelineState,
+        reason_code: str,
+        candidate_hash: str,
+        payload_digest: str,
+        decision_time: int,
+    ) -> CryptographicReceipt:
+        self._halted = True
+        return self._seal_receipt(
+            payload=payload,
+            status="EXECUTION_UNCERTAIN",
+            state=PipelineState.SU_EXECUTION_UNCERTAIN,
+            failed_at_state=failed_at_state,
+            reason_code=reason_code,
+            candidate_hash=candidate_hash,
+            payload_digest=payload_digest,
+            result_digest=GENESIS_HASH,
+            state_hash=self._state_head,
+            decision_time=decision_time,
+        )
+
+    def _seal_receipt(
+        self,
+        *,
+        payload: ExecutionPayload,
+        status: str,
+        state: PipelineState,
+        failed_at_state: Optional[PipelineState],
+        reason_code: Optional[str],
+        candidate_hash: str,
+        payload_digest: str,
+        result_digest: str,
+        state_hash: str,
+        decision_time: int,
+    ) -> CryptographicReceipt:
+        parent_audit_hash = self._audit_head
+        receipt_body = {
+            "protocol_version": PROTOCOL_VERSION,
+            "action_id": payload.action_id,
+            "authority_id": payload.authority_id,
+            "context_scope": payload.context_scope,
+            "nonce": payload.nonce,
+            "status": status,
+            "state": state.name,
+            "failed_at_state": failed_at_state.name if failed_at_state else None,
+            "reason_code": reason_code,
+            "candidate_hash": candidate_hash,
+            "payload_digest": payload_digest,
+            "result_digest": result_digest,
+            "parent_state_hash": self._state_head,
+            "state_hash": state_hash,
+            "parent_audit_hash": parent_audit_hash,
+            "decision_time": decision_time,
+            "receipt_public_key_hex": self._receipt_public_key_hex,
+        }
+        signing_bytes = _AUDIT_DOMAIN + self.canonicalize(receipt_body)
+        audit_hash = hashlib.sha256(signing_bytes).hexdigest()
+        signature_hex = self._receipt_signing_key.sign(signing_bytes).hex()
+        prefix = {"COMMITTED": "rcpt", "REFUSED": "ref"}.get(status, "unc")
+        self._audit_head = audit_hash
+
+        return CryptographicReceipt(
+            receipt_id=f"{prefix}_{audit_hash[:16]}",
+            protocol_version=PROTOCOL_VERSION,
+            action_id=payload.action_id,
+            authority_id=payload.authority_id,
+            context_scope=payload.context_scope,
+            nonce=payload.nonce,
+            status=status,
+            state=state.name,
+            failed_at_state=failed_at_state.name if failed_at_state else None,
+            reason_code=reason_code,
+            candidate_hash=candidate_hash,
+            payload_digest=payload_digest,
+            result_digest=result_digest,
+            parent_state_hash=self._state_head,
+            state_hash=state_hash,
+            parent_audit_hash=parent_audit_hash,
+            audit_hash=audit_hash,
+            decision_time=decision_time,
+            receipt_public_key_hex=self._receipt_public_key_hex,
+            receipt_signature_hex=signature_hex,
+        )
+
+    @classmethod
+    def verify_receipt(cls, receipt: CryptographicReceipt) -> bool:
+        body = {
+            "protocol_version": receipt.protocol_version,
+            "action_id": receipt.action_id,
+            "authority_id": receipt.authority_id,
+            "context_scope": receipt.context_scope,
+            "nonce": receipt.nonce,
+            "status": receipt.status,
+            "state": receipt.state,
+            "failed_at_state": receipt.failed_at_state,
+            "reason_code": receipt.reason_code,
+            "candidate_hash": receipt.candidate_hash,
+            "payload_digest": receipt.payload_digest,
+            "result_digest": receipt.result_digest,
+            "parent_state_hash": receipt.parent_state_hash,
+            "state_hash": receipt.state_hash,
+            "parent_audit_hash": receipt.parent_audit_hash,
+            "decision_time": receipt.decision_time,
+            "receipt_public_key_hex": receipt.receipt_public_key_hex,
+        }
+        signing_bytes = _AUDIT_DOMAIN + cls.canonicalize(body)
+        computed_audit_hash = hashlib.sha256(signing_bytes).hexdigest()
+        if computed_audit_hash != receipt.audit_hash:
+            return False
+        expected_prefix = {"COMMITTED": "rcpt", "REFUSED": "ref"}.get(
+            receipt.status, "unc"
+        )
+        if receipt.receipt_id != f"{expected_prefix}_{computed_audit_hash[:16]}":
+            return False
+        try:
+            public_key = ed25519.Ed25519PublicKey.from_public_bytes(
+                bytes.fromhex(receipt.receipt_public_key_hex)
+            )
+            public_key.verify(bytes.fromhex(receipt.receipt_signature_hex), signing_bytes)
+            return True
+        except (ValueError, InvalidSignature):
+            return False
+
+    @staticmethod
+    def _rollback_cleanly(effector: TwoPhaseEffector) -> bool:
+        try:
+            effector.rollback()
+            return True
+        except Exception:
+            return False
+
+    @classmethod
+    def _malformed_candidate_fingerprint(
+        cls, payload: ExecutionPayload, exc: Exception
+    ) -> str:
+        safe_identity = {
+            "protocol_version": str(payload.protocol_version),
+            "action_id": str(payload.action_id),
+            "authority_id": str(payload.authority_id),
+            "nonce": str(payload.nonce),
+            "error_type": type(exc).__name__,
+        }
+        return hashlib.sha256(
+            _PAYLOAD_DOMAIN + cls.canonicalize(safe_identity)
+        ).hexdigest()
+
+    @staticmethod
+    def _validate_hash(value: str, field_name: str) -> None:
+        try:
+            raw = bytes.fromhex(value)
+        except ValueError as exc:
+            raise ValueError(f"{field_name} must be hexadecimal") from exc
+        if len(raw) != 32:
+            raise ValueError(f"{field_name} must be a 32-byte SHA-256 value")

--- a/tas_pythonetics/tests/test_runtime.py
+++ b/tas_pythonetics/tests/test_runtime.py
@@ -1,0 +1,507 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import Any, Mapping
+
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ed25519
+
+from tas_pythonetics import (
+    AuthorityRecord,
+    AuthorityRegistry,
+    CapabilityRegistry,
+    CommitRejected,
+    ExecutionPayload,
+    HardenedPythoneticsRuntime,
+    PipelineState,
+    PreparationRejected,
+    PROTOCOL_VERSION,
+    TwoPhaseEffector,
+)
+
+NOW = 1_800_000_000
+
+
+class RecordingEffector(TwoPhaseEffector):
+    def __init__(self, mode: str = "success") -> None:
+        self.mode = mode
+        self.staged_state: Any = None
+        self.committed_state: Any = None
+        self.rollback_calls = 0
+
+    def prepare(self, parameters: Mapping[str, Any]) -> bool:
+        self.staged_state = parameters.get("value")
+        if self.mode in {"prepare_false", "prepare_false_rollback_failure"}:
+            return False
+        if self.mode == "prepare_reject":
+            raise PreparationRejected("policy rejected")
+        if self.mode in {"prepare_exception", "prepare_exception_rollback_failure"}:
+            raise RuntimeError("prepare failure")
+        return True
+
+    def commit(self) -> Mapping[str, Any]:
+        if self.mode in {"commit_reject", "commit_reject_rollback_failure"}:
+            raise CommitRejected("atomic store rejected transaction")
+        if self.mode == "commit_exception_after_effect":
+            self.committed_state = self.staged_state
+            raise RuntimeError("transport failed after commit")
+        self.committed_state = self.staged_state
+        self.staged_state = None
+        if self.mode == "bad_result":
+            return {"value": object()}
+        return {"value": self.committed_state}
+
+    def rollback(self) -> None:
+        self.rollback_calls += 1
+        if self.mode in {
+            "prepare_false_rollback_failure",
+            "prepare_exception_rollback_failure",
+            "commit_reject_rollback_failure",
+        }:
+            raise RuntimeError("rollback failure")
+        self.staged_state = None
+
+
+class RuntimeHarness:
+    def __init__(self, mode: str = "success") -> None:
+        self.authority_signing_key = ed25519.Ed25519PrivateKey.generate()
+        self.authority_public_key_hex = self.authority_signing_key.public_key().public_bytes(
+            encoding=serialization.Encoding.Raw,
+            format=serialization.PublicFormat.Raw,
+        ).hex()
+        self.receipt_signing_key = ed25519.Ed25519PrivateKey.generate()
+        self.effectors: list[RecordingEffector] = []
+
+        self.authorities = AuthorityRegistry()
+        self.authorities.register(
+            AuthorityRecord(
+                authority_id="auth_admin",
+                public_key_hex=self.authority_public_key_hex,
+                scopes=frozenset({"production.write", "production.read"}),
+                valid_from=NOW - 1_000,
+                valid_until=NOW + 1_000,
+            )
+        )
+        self.capabilities = CapabilityRegistry()
+        self.register_effector(mode=mode)
+        self.runtime = HardenedPythoneticsRuntime(
+            self.capabilities,
+            self.authorities,
+            self.receipt_signing_key,
+            clock=lambda: NOW,
+        )
+
+    def register_effector(
+        self,
+        *,
+        mode: str = "success",
+        action_id: str = "db_write",
+        scope: str = "production.write",
+        replace_existing: bool = False,
+    ) -> None:
+        def factory() -> RecordingEffector:
+            effector = RecordingEffector(mode)
+            self.effectors.append(effector)
+            return effector
+
+        self.capabilities.register(
+            action_id,
+            scope,
+            factory,
+            replace_existing=replace_existing,
+        )
+
+    def payload(self, **overrides: Any) -> ExecutionPayload:
+        values: dict[str, Any] = {
+            "protocol_version": PROTOCOL_VERSION,
+            "action_id": "db_write",
+            "authority_id": "auth_admin",
+            "public_key_hex": self.authority_public_key_hex,
+            "signature_hex": "",
+            "context_scope": "production.write",
+            "parameters": {"value": "data_v1"},
+            "issued_at": NOW - 1,
+            "expires_at": NOW + 60,
+            "nonce": f"nonce_{len(self.effectors)}_{id(overrides)}",
+            "parent_state_hash": self.runtime.latest_state_hash,
+        }
+        explicit_signature = overrides.pop("signature_hex", None)
+        signing_key = overrides.pop("_signing_key", self.authority_signing_key)
+        values.update(overrides)
+        unsigned = ExecutionPayload(**values)
+        values["signature_hex"] = signing_key.sign(
+            self.runtime.compute_candidate_preimage(unsigned)
+        ).hex()
+        if explicit_signature is not None:
+            values["signature_hex"] = explicit_signature
+        return ExecutionPayload(**values)
+
+
+def test_successful_admitted_transition_is_signed_and_advances_both_heads() -> None:
+    h = RuntimeHarness()
+    initial_state = h.runtime.latest_state_hash
+    initial_audit = h.runtime.latest_audit_hash
+
+    receipt = h.runtime.process_transition(h.payload(nonce="success-1"))
+
+    assert receipt.status == "COMMITTED"
+    assert receipt.state == PipelineState.S7_COMMITTED_AND_SEALED.name
+    assert h.effectors[-1].committed_state == "data_v1"
+    assert receipt.parent_state_hash == initial_state
+    assert receipt.parent_audit_hash == initial_audit
+    assert receipt.state_hash == h.runtime.latest_state_hash != initial_state
+    assert receipt.audit_hash == h.runtime.latest_audit_hash != initial_audit
+    assert receipt.result_digest != "0" * 64
+    assert HardenedPythoneticsRuntime.verify_receipt(receipt)
+
+
+def test_refusal_is_evidentiary_and_does_not_advance_state() -> None:
+    h = RuntimeHarness()
+    initial_state = h.runtime.latest_state_hash
+    initial_audit = h.runtime.latest_audit_hash
+
+    receipt = h.runtime.process_transition(
+        h.payload(nonce="bad-sig", signature_hex="00" * 64)
+    )
+
+    assert receipt.status == "REFUSED"
+    assert receipt.reason_code == "ERR_INVALID_CRYPTO_SIGNATURE"
+    assert receipt.candidate_hash != "0" * 64
+    assert receipt.audit_hash != initial_audit
+    assert h.runtime.latest_state_hash == initial_state
+    assert h.runtime.latest_audit_hash == receipt.audit_hash
+    assert HardenedPythoneticsRuntime.verify_receipt(receipt)
+
+
+def test_preparation_refusal_implies_zero_protected_effect() -> None:
+    h = RuntimeHarness(mode="prepare_false")
+    receipt = h.runtime.process_transition(h.payload(nonce="prepare-false"))
+    effector = h.effectors[-1]
+
+    assert receipt.status == "REFUSED"
+    assert receipt.reason_code == "ERR_EFFECTOR_PREPARATION_REJECTED"
+    assert effector.committed_state is None
+    assert effector.staged_state is None
+    assert effector.rollback_calls == 1
+
+
+@pytest.mark.parametrize("mode", ["prepare_reject", "prepare_exception"])
+def test_prepare_rejection_or_exception_rolls_back_cleanly(mode: str) -> None:
+    h = RuntimeHarness(mode=mode)
+    receipt = h.runtime.process_transition(h.payload(nonce=mode))
+
+    assert receipt.status == "REFUSED"
+    assert h.effectors[-1].committed_state is None
+    assert h.effectors[-1].staged_state is None
+
+
+def test_explicit_commit_rejection_can_truthfully_emit_refusal() -> None:
+    h = RuntimeHarness(mode="commit_reject")
+    receipt = h.runtime.process_transition(h.payload(nonce="commit-reject"))
+    effector = h.effectors[-1]
+
+    assert receipt.status == "REFUSED"
+    assert receipt.reason_code == "ERR_EFFECTOR_COMMIT_REJECTED"
+    assert effector.committed_state is None
+    assert effector.staged_state is None
+
+
+def test_unexpected_commit_exception_is_uncertain_not_refused_and_halts_runtime() -> None:
+    h = RuntimeHarness(mode="commit_exception_after_effect")
+    state_before = h.runtime.latest_state_hash
+
+    receipt = h.runtime.process_transition(h.payload(nonce="uncertain-1"))
+
+    assert receipt.status == "EXECUTION_UNCERTAIN"
+    assert receipt.state == PipelineState.SU_EXECUTION_UNCERTAIN.name
+    assert receipt.reason_code == "ERR_COMMIT_OUTCOME_UNKNOWN:RuntimeError"
+    assert h.effectors[-1].committed_state == "data_v1"
+    assert h.runtime.latest_state_hash == state_before
+    assert h.runtime.halted
+
+    next_receipt = h.runtime.process_transition(h.payload(nonce="blocked-after-uncertain"))
+    assert next_receipt.status == "REFUSED"
+    assert next_receipt.reason_code == "ERR_RUNTIME_HALTED_PENDING_RECONCILIATION"
+
+
+@pytest.mark.parametrize(
+    ("mode", "expected_reason"),
+    [
+        (
+            "prepare_exception_rollback_failure",
+            "ERR_PREPARE_AND_ROLLBACK_FAILED:RuntimeError",
+        ),
+        (
+            "commit_reject_rollback_failure",
+            "ERR_ROLLBACK_FAILED_AFTER_COMMIT_REJECTION",
+        ),
+    ],
+)
+def test_cleanup_failure_is_execution_uncertain(mode: str, expected_reason: str) -> None:
+    h = RuntimeHarness(mode=mode)
+    receipt = h.runtime.process_transition(h.payload(nonce=mode))
+
+    assert receipt.status == "EXECUTION_UNCERTAIN"
+    assert receipt.reason_code == expected_reason
+    assert h.runtime.halted
+
+
+def test_noncanonical_committed_result_is_uncertain() -> None:
+    h = RuntimeHarness(mode="bad_result")
+    receipt = h.runtime.process_transition(h.payload(nonce="bad-result"))
+
+    assert receipt.status == "EXECUTION_UNCERTAIN"
+    assert receipt.reason_code.startswith("ERR_COMMITTED_RESULT_NOT_CANONICALIZABLE:")
+    assert h.effectors[-1].committed_state == "data_v1"
+
+
+def test_replay_nonce_is_consumed_even_when_capability_is_missing() -> None:
+    h = RuntimeHarness()
+    first = h.payload(action_id="missing", nonce="one-shot")
+    receipt1 = h.runtime.process_transition(first)
+    assert receipt1.reason_code == "ERR_UNREGISTERED_CAPABILITY"
+
+    h.register_effector(action_id="missing", replace_existing=False)
+    replay = h.payload(action_id="missing", nonce="one-shot")
+    receipt2 = h.runtime.process_transition(replay)
+    assert receipt2.reason_code == "ERR_REPLAY_NONCE_DETECTED"
+
+
+@pytest.mark.parametrize(
+    ("overrides", "reason"),
+    [
+        ({"protocol_version": "legacy-v0"}, "ERR_UNSUPPORTED_PROTOCOL_VERSION"),
+        ({"action_id": ""}, "ERR_REQUIRED_FIELD_EMPTY"),
+        ({"issued_at": NOW + 10, "expires_at": NOW}, "ERR_INVERTED_VALIDITY_WINDOW"),
+        ({"issued_at": NOW, "expires_at": NOW + 301}, "ERR_VALIDITY_WINDOW_TOO_LONG"),
+        ({"issued_at": NOW - 100, "expires_at": NOW - 1}, "ERR_CANDIDATE_NOT_CURRENTLY_EFFECTIVE"),
+        ({"parent_state_hash": "11" * 32}, "ERR_PARENT_STATE_MISMATCH"),
+    ],
+)
+def test_context_and_protocol_failures(overrides: dict[str, Any], reason: str) -> None:
+    h = RuntimeHarness()
+    receipt = h.runtime.process_transition(h.payload(nonce=reason, **overrides))
+    assert receipt.status == "REFUSED"
+    assert receipt.reason_code == reason
+
+
+def test_unknown_authority_is_rejected_after_valid_signature() -> None:
+    h = RuntimeHarness()
+    receipt = h.runtime.process_transition(
+        h.payload(authority_id="unknown", nonce="unknown-authority")
+    )
+    assert receipt.reason_code == "ERR_UNKNOWN_EXTERNAL_AUTHORITY"
+
+
+def test_authority_key_mismatch_is_rejected() -> None:
+    h = RuntimeHarness()
+    other_key = ed25519.Ed25519PrivateKey.generate()
+    other_public_hex = other_key.public_key().public_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PublicFormat.Raw,
+    ).hex()
+    receipt = h.runtime.process_transition(
+        h.payload(
+            public_key_hex=other_public_hex,
+            _signing_key=other_key,
+            nonce="key-mismatch",
+        )
+    )
+    assert receipt.reason_code == "ERR_AUTHORITY_KEY_MISMATCH"
+
+
+def test_revoked_authority_and_ungranted_scope_are_rejected() -> None:
+    h = RuntimeHarness()
+    h.authorities.revoke("auth_admin", NOW)
+    revoked = h.runtime.process_transition(h.payload(nonce="revoked"))
+    assert revoked.reason_code == "ERR_AUTHORITY_NOT_CURRENTLY_EFFECTIVE"
+
+    h2 = RuntimeHarness()
+    scope = h2.runtime.process_transition(
+        h2.payload(context_scope="production.delete", nonce="bad-scope")
+    )
+    assert scope.reason_code == "ERR_SCOPE_NOT_GRANTED_BY_AUTHORITY"
+
+
+def test_candidate_must_fit_inside_authority_window() -> None:
+    h = RuntimeHarness()
+    h.authorities.register(
+        AuthorityRecord(
+            authority_id="auth_admin",
+            public_key_hex=h.authority_public_key_hex,
+            scopes=frozenset({"production.write"}),
+            valid_from=NOW - 10,
+            valid_until=NOW + 10,
+        ),
+        replace_existing=True,
+    )
+    receipt = h.runtime.process_transition(
+        h.payload(issued_at=NOW - 20, expires_at=NOW + 1, nonce="outside-window")
+    )
+    assert receipt.reason_code == "ERR_CANDIDATE_OUTSIDE_AUTHORITY_WINDOW"
+
+
+def test_capability_scope_factory_and_contract_failures() -> None:
+    h = RuntimeHarness()
+    h.register_effector(
+        action_id="wrong_scope",
+        scope="production.read",
+    )
+    mismatch = h.runtime.process_transition(
+        h.payload(action_id="wrong_scope", nonce="scope-mismatch")
+    )
+    assert mismatch.reason_code == "ERR_CAPABILITY_SCOPE_MISMATCH"
+
+    h.capabilities.register(
+        "factory_error",
+        "production.write",
+        lambda: (_ for _ in ()).throw(RuntimeError("factory")),
+    )
+    factory_error = h.runtime.process_transition(
+        h.payload(action_id="factory_error", nonce="factory-error")
+    )
+    assert factory_error.reason_code == "ERR_EFFECTOR_FACTORY:RuntimeError"
+
+    h.capabilities.register("bad_contract", "production.write", lambda: object())
+    bad_contract = h.runtime.process_transition(
+        h.payload(action_id="bad_contract", nonce="bad-contract")
+    )
+    assert bad_contract.reason_code == "ERR_EFFECTOR_CONTRACT_VIOLATION"
+
+
+def test_malformed_parameters_are_refused_with_fingerprint() -> None:
+    h = RuntimeHarness()
+    payload = ExecutionPayload(
+        protocol_version=PROTOCOL_VERSION,
+        action_id="db_write",
+        authority_id="auth_admin",
+        public_key_hex=h.authority_public_key_hex,
+        signature_hex="",
+        context_scope="production.write",
+        parameters={"not_json": object()},
+        issued_at=NOW - 1,
+        expires_at=NOW + 60,
+        nonce="malformed",
+        parent_state_hash=h.runtime.latest_state_hash,
+    )
+    receipt = h.runtime.process_transition(payload)
+    assert receipt.status == "REFUSED"
+    assert receipt.reason_code == "ERR_CANDIDATE_NOT_CANONICALIZABLE"
+    assert receipt.candidate_hash != "0" * 64
+
+
+def test_receipt_verification_detects_hash_and_signature_tampering() -> None:
+    h = RuntimeHarness()
+    receipt = h.runtime.process_transition(h.payload(nonce="verify-receipt"))
+    assert HardenedPythoneticsRuntime.verify_receipt(receipt)
+    assert not HardenedPythoneticsRuntime.verify_receipt(
+        replace(receipt, audit_hash="11" * 32)
+    )
+    assert not HardenedPythoneticsRuntime.verify_receipt(
+        replace(receipt, receipt_id="rcpt_tampered")
+    )
+    assert not HardenedPythoneticsRuntime.verify_receipt(
+        replace(receipt, receipt_signature_hex="00" * 64)
+    )
+    assert not HardenedPythoneticsRuntime.verify_receipt(
+        replace(receipt, receipt_public_key_hex="not-hex")
+    )
+
+
+def test_invalid_signature_encoding_is_refused() -> None:
+    h = RuntimeHarness()
+    receipt = h.runtime.process_transition(
+        h.payload(nonce="bad-encoding", signature_hex="not-hex")
+    )
+    assert receipt.reason_code == "ERR_INVALID_CRYPTO_SIGNATURE"
+
+
+def test_registry_validation_and_replacement() -> None:
+    authorities = AuthorityRegistry()
+    key = ed25519.Ed25519PrivateKey.generate().public_key().public_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PublicFormat.Raw,
+    ).hex()
+    record = AuthorityRecord("a", key, frozenset({"s"}), 1, 2)
+    authorities.register(record)
+    assert authorities.resolve("a") is not None
+    with pytest.raises(ValueError, match="already registered"):
+        authorities.register(record)
+    authorities.register(record, replace_existing=True)
+    with pytest.raises(KeyError):
+        authorities.revoke("missing", 2)
+
+    for bad_record, message in [
+        (AuthorityRecord("", key, frozenset({"s"}), 1, 2), "authority_id"),
+        (AuthorityRecord("a", key, frozenset(), 1, 2), "at least one scope"),
+        (AuthorityRecord("a", key, frozenset({"s"}), 2, 1), "inverted"),
+        (AuthorityRecord("a", "zz", frozenset({"s"}), 1, 2), "hexadecimal"),
+        (AuthorityRecord("a", "00", frozenset({"s"}), 1, 2), "32 bytes"),
+    ]:
+        with pytest.raises(ValueError, match=message):
+            AuthorityRegistry().register(bad_record)
+
+    capabilities = CapabilityRegistry()
+    factory = lambda: RecordingEffector()
+    capabilities.register("a", "s", factory)
+    assert capabilities.resolve("a") is not None
+    with pytest.raises(ValueError, match="already registered"):
+        capabilities.register("a", "s", factory)
+    capabilities.register("a", "s", factory, replace_existing=True)
+    with pytest.raises(ValueError, match="non-empty"):
+        capabilities.register("", "s", factory)
+    with pytest.raises(TypeError, match="callable"):
+        capabilities.register("b", "s", object())  # type: ignore[arg-type]
+
+
+def test_compute_candidate_hash_and_short_signature_path() -> None:
+    h = RuntimeHarness()
+    payload = h.payload(nonce="hash-helper")
+    assert h.runtime.compute_candidate_hash(payload) == receipt_candidate_hash(payload, h.runtime)
+
+    short_signature = h.runtime.process_transition(
+        h.payload(nonce="short-signature", signature_hex="00")
+    )
+    assert short_signature.reason_code == "ERR_INVALID_CRYPTO_SIGNATURE"
+
+
+def receipt_candidate_hash(payload: ExecutionPayload, runtime: HardenedPythoneticsRuntime) -> str:
+    import hashlib
+
+    return hashlib.sha256(runtime.compute_candidate_preimage(payload)).hexdigest()
+
+
+def test_prepare_rejection_with_rollback_failure_is_uncertain() -> None:
+    h = RuntimeHarness(mode="prepare_false_rollback_failure")
+    receipt = h.runtime.process_transition(h.payload(nonce="prepare-false-rollback-fail"))
+    assert receipt.status == "EXECUTION_UNCERTAIN"
+    assert receipt.reason_code == "ERR_ROLLBACK_FAILED_AFTER_PREPARATION_REJECTION"
+
+
+def test_authority_record_outside_effective_window() -> None:
+    key = ed25519.Ed25519PrivateKey.generate().public_key().public_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PublicFormat.Raw,
+    ).hex()
+    record = AuthorityRecord("a", key, frozenset({"s"}), 10, 20)
+    assert not record.effective_at(9)
+    assert record.effective_at(10)
+
+
+def test_runtime_constructor_validation() -> None:
+    capabilities = CapabilityRegistry()
+    authorities = AuthorityRegistry()
+    signing_key = ed25519.Ed25519PrivateKey.generate()
+    with pytest.raises(ValueError, match="hexadecimal"):
+        HardenedPythoneticsRuntime(
+            capabilities, authorities, signing_key, genesis_hash="zz"
+        )
+    with pytest.raises(ValueError, match="32-byte"):
+        HardenedPythoneticsRuntime(
+            capabilities, authorities, signing_key, genesis_hash="00"
+        )
+    with pytest.raises(ValueError, match="positive"):
+        HardenedPythoneticsRuntime(
+            capabilities, authorities, signing_key, max_candidate_lifetime=0
+        )


### PR DESCRIPTION
## What changed

- Adds immutable payload, authority, state, and signed receipt types.
- Adds an externally lodged `AuthorityRegistry` with effective-time, revocation, key, and exact-scope validation.
- Adds a `CapabilityRegistry` that resolves actions only to internal per-transition effector factories.
- Adds `HardenedPythoneticsRuntime` with Ed25519 candidate verification, RFC 8785 canonicalization, domain-separated hashes, lineage binding, one-shot nonce reservation, and signed decision receipts.
- Separates protected state lineage from the audit lineage so refusal evidence can advance the audit chain without mutating protected state.
- Adds 30 conformance tests and a CI gate requiring 100% line coverage across the new runtime modules.
- Documents the process-local persistence boundary for nonce and head storage.

## Why

The previous prototype could describe a refusal after an execution-side failure even when the protected world might already have changed. That violates the load-bearing invariant:

```text
REFUSED => protected state delta is zero
```

This implementation permits `REFUSED` only before commit or after an explicit `CommitRejected` guarantee. Any unexpected commit exception becomes `EXECUTION_UNCERTAIN`; the runtime emits signed evidence and halts pending external reconciliation rather than misrepresenting the outcome.

## Terminal decision semantics

- `COMMITTED`: effect confirmed; state and audit heads advance.
- `REFUSED`: zero protected effect; only the audit head advances.
- `EXECUTION_UNCERTAIN`: outcome cannot be proven; audit head advances and execution halts.

## Validation evidence

Validated head commit:

```text
0ec28a2f4f17b9e54fea4ce6a964ddc980f26318
```

- **Python Tests** — run #481, run ID `30924913233`: **success**
- **Sovereign Truth Convergence** — run #633, run ID `30924913692`: **success**
- Focused runtime conformance: **30 tests passed**
- New governed-runtime modules: **100% line coverage**

The convergence workflow was also corrected to install the declared runtime dependencies before importing `tas_pythonetics`.

## Deployment boundary

The included nonce set and state/audit heads are process-local reference storage. Multi-process, crash-persistent, or distributed deployment requires a durable atomic state store before production durability can be claimed.