### PR TITLE
chore(tas): update kinematic identity for github actions workflow

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -17,4 +17,4 @@ jobs:
         run: python -m pip install pytest -r requirements.txt
       - name: Run tests
         run: PYTHONPATH=$(pwd)/tas_pythonetics/src:$(pwd)/tas-recursion-conversion:$(pwd) pytest -q
-# Nonce: 56328
+# Nonce: 11491

--- a/.github/workflows/python-tests.yml.tasmeta.json
+++ b/.github/workflows/python-tests.yml.tasmeta.json
@@ -1,12 +1,12 @@
 {
-  "id": "9d8f4b54c8cd6160766e2dde4e88f659ef0a00bcb7c8abc4b0fcab7ce496e3a8",
+  "id": "ecd9c2544a09889f6e537486c9b9d844781b6663ab267606172bfe96c7a828a2",
   "type": "TasArtifact",
-  "form_id": "72c796f970065108c90ff94e43d792727e63d0e7d5824bad98d8f95e3d9662bb",
+  "form_id": "d2b6bc8b18e95c8dc0e2eb7f56d1dc2257ad2f2137844fb9fcb878f49ffb916d",
   "genome_id": "TAS_GENOME_V1",
-  "lineage_id": "9d8f4b54c8cd6160766e2dde4e88f659ef0a00bcb7c8abc4b0fcab7ce496e3a8",
+  "lineage_id": "ecd9c2544a09889f6e537486c9b9d844781b6663ab267606172bfe96c7a828a2",
   "h_seed": "Russell Nordland",
-  "cert_id": "a4300dfe-4b63-4295-8ae2-253f53b5a7fc",
-  "timestamp": "2026-04-20T15:50:16.952432+00:00",
+  "cert_id": "dcf3bbb5-623b-4be6-9da9-aaf2df125be9",
+  "timestamp": "2026-08-08T01:22:33.433682+00:00",
   "paradata_trail": [],
   "signatures": [
     {


### PR DESCRIPTION
Ran the TrueAlphaSpiral routine to update the kinematic identity and sequence drifted artifacts, specifically the `.github/workflows/python-tests.yml` file.

---
*PR created automatically by Jules for task [18239576867584970611](https://jules.google.com/task/18239576867584970611) started by @TrueAlpha-spiral*